### PR TITLE
Remove style lint rules and enforce warnings as errors in lint scripts

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -21,18 +21,6 @@
             "allow": ["error", "info", "warn"]
           }
         }
-      },
-      "style": {
-        "noParameterAssign": "error",
-        "useAsConstAssertion": "error",
-        "useDefaultParameterLast": "error",
-        "useEnumInitializers": "error",
-        "useSelfClosingElements": "error",
-        "useSingleVarDeclarator": "error",
-        "noUnusedTemplateLiteral": "error",
-        "useNumberNamespace": "error",
-        "noInferrableTypes": "error",
-        "noUselessElse": "error"
       }
     }
   }

--- a/packages/backend_app/package.json
+++ b/packages/backend_app/package.json
@@ -5,7 +5,7 @@
     "db:studio": "drizzle-kit studio",
     "db:push": "bun run --bun drizzle-kit push",
     "typecheck": "bun run --bun tsc --noEmit",
-    "lint": "bun run --bun biome check .",
+    "lint": "bun run --bun biome check . --error-on-warnings",
     "lint:fix": "bun run lint --write",
     "test:db:push": "bun --env-file=.env.test run --bun drizzle-kit push",
     "test:local": "bun --env-file=.env.test test",

--- a/packages/frontend_app/package.json
+++ b/packages/frontend_app/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "typecheck": "tsc --noEmit",
-    "lint": "biome check .",
+    "lint": "biome check . --error-on-warnings",
     "lint:fix": "biome check . --write"
   },
   "dependencies": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to remove style-related rules.
  * Modified lint scripts to treat warnings as errors during linting for both backend and frontend applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->