### PR TITLE
Enforce noFloatingPromises, set TS target to ESNext, simplify OpenAPI script

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -21,6 +21,9 @@
             "allow": ["error", "info", "warn"]
           }
         }
+      },
+      "nursery": {
+        "noFloatingPromises": "error"
       }
     }
   }

--- a/packages/backend_app/src/scripts/export-openapi/index.ts
+++ b/packages/backend_app/src/scripts/export-openapi/index.ts
@@ -2,4 +2,17 @@ import { exportOpenAPI } from "./functions";
 
 await exportOpenAPI();
 
-Bun.spawnSync(["biome", "check", "openapi.json", "--write"]);
+const { success, stdout } = Bun.spawnSync([
+  "bun",
+  "--bun",
+  "biome",
+  "check",
+  "openapi.json",
+  "--write",
+]);
+
+if (success) {
+  console.info(stdout.toString());
+} else {
+  console.error("biome check failed");
+}

--- a/packages/backend_app/src/scripts/export-openapi/index.ts
+++ b/packages/backend_app/src/scripts/export-openapi/index.ts
@@ -1,20 +1,5 @@
 import { exportOpenAPI } from "./functions";
 
-(async () => {
-  await exportOpenAPI();
+await exportOpenAPI();
 
-  const { success, stdout } = Bun.spawnSync([
-    "bun",
-    "--bun",
-    "biome",
-    "check",
-    "openapi.json",
-    "--write",
-  ]);
-
-  if (success) {
-    console.info(stdout.toString());
-  } else {
-    console.error("biome check failed");
-  }
-})();
+Bun.spawnSync(["biome", "check", "openapi.json", "--write"]);

--- a/packages/backend_app/tsconfig.json
+++ b/packages/backend_app/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Bundler"
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated linter configuration to enforce stricter rules against floating promises.
  * Simplified script execution for exporting OpenAPI documentation.
  * Set TypeScript output target to ESNext for improved compatibility with modern JavaScript features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->