### PR TITLE
Refactor E2E PostCard tests to use data-testid; add root testid

### DIFF
--- a/packages/e2e/tests/scenarios/post/index.spec.ts
+++ b/packages/e2e/tests/scenarios/post/index.spec.ts
@@ -25,30 +25,30 @@ test("post page", async ({ page }) => {
     await expect.soft(page).toHaveScreenshot(screenshotOptions);
   });
 
-  const createTextArea = page.getByPlaceholder(
-    "Write your post content here...",
-  );
   const firstPostContent = `This is first post content`;
   const secondPostContent = `This is second post content`;
 
-  const postCards = page.getByTestId("postCard");
-  const firstPostCard = postCards.filter({ hasText: firstPostContent });
-  const secondPostCard = postCards.filter({ hasText: secondPostContent });
+  const firstPostCard = page.getByTestId("postCard1");
+  const secondPostCard = page.getByTestId("postCard2");
 
   await test.step("create posts", async () => {
+    const createTextArea = page.getByPlaceholder(
+      "Write your post content here...",
+    );
+    const createPostButton = page.getByRole("button", { name: "Create Post" });
+
     await test.step("create first post", async () => {
       await createTextArea.fill(firstPostContent);
-      await page.getByRole("button", { name: "Create Post" }).click();
+      await createPostButton.click();
       await expect(createTextArea).toHaveValue("");
 
-      await expect(postCards).toHaveCount(1);
       await expect(firstPostCard).toBeVisible();
       await expect.soft(page).toHaveScreenshot(screenshotOptions);
     });
 
     await test.step("create second post", async () => {
       await createTextArea.fill(secondPostContent);
-      await page.getByRole("button", { name: "Create Post" }).click();
+      await createPostButton.click();
       await expect(createTextArea).toHaveValue("");
 
       await expect(secondPostCard).toBeVisible();
@@ -56,9 +56,9 @@ test("post page", async ({ page }) => {
     });
   });
 
-  const updatedPostContent = `This is updated post content`;
   await test.step("update post", async () => {
     const editTextArea = firstPostCard.getByRole("textbox");
+    const updatedPostContent = `This is updated post content`;
 
     await test.step("check first post edit button", async () => {
       await firstPostCard.getByRole("button", { name: "Edit" }).click();
@@ -71,28 +71,19 @@ test("post page", async ({ page }) => {
       await expect(firstPostCard.getByText("New")).toBeVisible();
 
       await editTextArea.fill(updatedPostContent);
-      await page.getByRole("button", { name: "Save" }).click();
-      const updatedPostCard = postCards.filter({ hasText: updatedPostContent });
-      await expect(updatedPostCard).toBeVisible();
-
-      await expect(firstPostCard.getByText(firstPostContent)).not.toBeVisible();
+      await firstPostCard.getByRole("button", { name: "Save" }).click();
+      await expect(firstPostCard.getByText(updatedPostContent)).toBeVisible();
       await expect(firstPostCard.getByText("New")).not.toBeVisible();
-
       await expect.soft(page).toHaveScreenshot(screenshotOptions);
     });
 
     await test.step("cancel update second post", async () => {
       await secondPostCard.getByRole("button", { name: "Edit" }).click();
-      const notUpdatedPostContent = "This is not updated post content";
-      await secondPostCard.getByRole("textbox").fill(notUpdatedPostContent);
-      const updatingPostCard = postCards.filter({
-        hasText: notUpdatedPostContent,
-      });
-      await expect(updatingPostCard).toBeVisible();
-
-      await updatingPostCard.getByRole("button", { name: "Cancel" }).click();
+      await secondPostCard
+        .getByRole("textbox")
+        .fill("This is not updated post content");
+      await secondPostCard.getByRole("button", { name: "Cancel" }).click();
       await expect(secondPostCard.getByText(secondPostContent)).toBeVisible();
-      await expect(updatingPostCard).not.toBeVisible();
     });
   });
 

--- a/packages/e2e/tests/scenarios/post/index.spec.ts
+++ b/packages/e2e/tests/scenarios/post/index.spec.ts
@@ -31,14 +31,16 @@ test("post page", async ({ page }) => {
   const firstPostContent = `This is first post content`;
   const secondPostContent = `This is second post content`;
 
+  const postCards = page.getByTestId("postCard");
+  const firstPostCard = postCards.filter({ hasText: firstPostContent });
+  const secondPostCard = postCards.filter({ hasText: secondPostContent });
+
   await test.step("create posts", async () => {
     await test.step("create first post", async () => {
       await createTextArea.fill(firstPostContent);
       await page.getByRole("button", { name: "Create Post" }).click();
       await expect(createTextArea).toHaveValue("");
 
-      const postCards = page.getByTestId("postCard");
-      const firstPostCard = postCards.filter({ hasText: firstPostContent });
       await expect(postCards).toHaveCount(1);
       await expect(firstPostCard).toBeVisible();
       await expect.soft(page).toHaveScreenshot(screenshotOptions);
@@ -49,16 +51,10 @@ test("post page", async ({ page }) => {
       await page.getByRole("button", { name: "Create Post" }).click();
       await expect(createTextArea).toHaveValue("");
 
-      const postCards = page.getByTestId("postCard");
-      const secondPostCard = postCards.filter({ hasText: secondPostContent });
       await expect(secondPostCard).toBeVisible();
       await expect.soft(page).toHaveScreenshot(screenshotOptions);
     });
   });
-
-  const postCards = page.getByTestId("postCard");
-  const firstPostCard = postCards.filter({ hasText: firstPostContent });
-  const secondPostCard = postCards.filter({ hasText: secondPostContent });
 
   const updatedPostContent = `This is updated post content`;
   await test.step("update post", async () => {

--- a/packages/e2e/tests/scenarios/post/index.spec.ts
+++ b/packages/e2e/tests/scenarios/post/index.spec.ts
@@ -28,8 +28,8 @@ test("post page", async ({ page }) => {
   const firstPostContent = `This is first post content`;
   const secondPostContent = `This is second post content`;
 
-  const firstPostCard = page.getByTestId("postCard1");
-  const secondPostCard = page.getByTestId("postCard2");
+  const firstPostCard = page.getByTestId("PostCard-1");
+  const secondPostCard = page.getByTestId("PostCard-2");
 
   await test.step("create posts", async () => {
     const createTextArea = page.getByPlaceholder(

--- a/packages/e2e/tests/scenarios/post/index.spec.ts
+++ b/packages/e2e/tests/scenarios/post/index.spec.ts
@@ -30,12 +30,17 @@ test("post page", async ({ page }) => {
   );
   const firstPostContent = `This is first post content`;
   const secondPostContent = `This is second post content`;
+
   await test.step("create posts", async () => {
     await test.step("create first post", async () => {
       await createTextArea.fill(firstPostContent);
       await page.getByRole("button", { name: "Create Post" }).click();
       await expect(createTextArea).toHaveValue("");
-      await expect(page.getByText(firstPostContent)).toBeVisible();
+
+      const postCards = page.getByTestId("postCard");
+      const firstPostCard = postCards.filter({ hasText: firstPostContent });
+      await expect(postCards).toHaveCount(1);
+      await expect(firstPostCard).toBeVisible();
       await expect.soft(page).toHaveScreenshot(screenshotOptions);
     });
 
@@ -43,46 +48,61 @@ test("post page", async ({ page }) => {
       await createTextArea.fill(secondPostContent);
       await page.getByRole("button", { name: "Create Post" }).click();
       await expect(createTextArea).toHaveValue("");
-      await expect(page.getByText(secondPostContent)).toBeVisible();
+
+      const postCards = page.getByTestId("postCard");
+      const secondPostCard = postCards.filter({ hasText: secondPostContent });
+      await expect(secondPostCard).toBeVisible();
       await expect.soft(page).toHaveScreenshot(screenshotOptions);
     });
   });
 
+  const postCards = page.getByTestId("postCard");
+  const firstPostCard = postCards.filter({ hasText: firstPostContent });
+  const secondPostCard = postCards.filter({ hasText: secondPostContent });
+
   const updatedPostContent = `This is updated post content`;
   await test.step("update post", async () => {
-    const editTextArea = page.getByRole("textbox").nth(1);
+    const editTextArea = firstPostCard.getByRole("textbox");
 
     await test.step("check first post edit button", async () => {
-      await page.getByRole("button", { name: "Edit" }).nth(1).click();
+      await firstPostCard.getByRole("button", { name: "Edit" }).click();
       await expect(editTextArea).toBeVisible();
       await expect.soft(page).toHaveScreenshot(screenshotOptions);
     });
 
     await test.step("update first post", async () => {
-      await expect(page.getByText(firstPostContent)).toBeVisible();
-      await expect(page.getByText("New").nth(2)).toBeVisible();
+      await expect(firstPostCard.getByText(firstPostContent)).toBeVisible();
+      await expect(firstPostCard.getByText("New")).toBeVisible();
 
       await editTextArea.fill(updatedPostContent);
       await page.getByRole("button", { name: "Save" }).click();
-      await expect(page.getByText(updatedPostContent)).toBeVisible();
+      const updatedPostCard = postCards.filter({ hasText: updatedPostContent });
+      await expect(updatedPostCard).toBeVisible();
 
-      await expect(page.getByText(firstPostContent)).not.toBeVisible();
-      await expect(page.getByText("New").nth(2)).not.toBeVisible();
+      await expect(firstPostCard.getByText(firstPostContent)).not.toBeVisible();
+      await expect(firstPostCard.getByText("New")).not.toBeVisible();
 
       await expect.soft(page).toHaveScreenshot(screenshotOptions);
     });
 
-    await test.step("cancel update first post", async () => {
-      await page.getByRole("button", { name: "Edit" }).nth(1).click();
-      await editTextArea.fill("This is not updated post content");
-      await page.getByRole("button", { name: "Cancel" }).click();
-      await expect(page.getByText(updatedPostContent)).toBeVisible();
+    await test.step("cancel update second post", async () => {
+      await secondPostCard.getByRole("button", { name: "Edit" }).click();
+      const notUpdatedPostContent = "This is not updated post content";
+      await secondPostCard.getByRole("textbox").fill(notUpdatedPostContent);
+      const updatingPostCard = postCards.filter({
+        hasText: notUpdatedPostContent,
+      });
+      await expect(updatingPostCard).toBeVisible();
+
+      await updatingPostCard.getByRole("button", { name: "Cancel" }).click();
+      await expect(secondPostCard.getByText(secondPostContent)).toBeVisible();
+      await expect(updatingPostCard).not.toBeVisible();
     });
   });
 
   await test.step("delete second post", async () => {
-    await page.getByRole("button", { name: "Delete" }).first().click();
-    await expect(page.getByText(secondPostContent)).not.toBeVisible();
+    await secondPostCard.getByRole("button", { name: "Delete" }).click();
+    await expect(secondPostCard).not.toBeVisible();
     await expect.soft(page).toHaveScreenshot(screenshotOptions);
   });
 });

--- a/packages/frontend_app/src/components/pages/post/components/PostCard/index.tsx
+++ b/packages/frontend_app/src/components/pages/post/components/PostCard/index.tsx
@@ -68,7 +68,7 @@ export const PostCard = ({ post, invalidatePostsQuery }: PostCardProps) => {
 
   return (
     <div
-      data-testid="postCard"
+      data-testid={`postCard${post.id}`}
       className="bg-white rounded-lg shadow-sm border border-gray-200 hover:shadow-md transition-shadow duration-200 overflow-hidden"
     >
       <div className="p-6">

--- a/packages/frontend_app/src/components/pages/post/components/PostCard/index.tsx
+++ b/packages/frontend_app/src/components/pages/post/components/PostCard/index.tsx
@@ -68,7 +68,7 @@ export const PostCard = ({ post, invalidatePostsQuery }: PostCardProps) => {
 
   return (
     <div
-      data-testid={`postCard${post.id}`}
+      data-testid={`PostCard-${post.id}`}
       className="bg-white rounded-lg shadow-sm border border-gray-200 hover:shadow-md transition-shadow duration-200 overflow-hidden"
     >
       <div className="p-6">

--- a/packages/frontend_app/src/components/pages/post/components/PostCard/index.tsx
+++ b/packages/frontend_app/src/components/pages/post/components/PostCard/index.tsx
@@ -67,7 +67,10 @@ export const PostCard = ({ post, invalidatePostsQuery }: PostCardProps) => {
   };
 
   return (
-    <div className="bg-white rounded-lg shadow-sm border border-gray-200 hover:shadow-md transition-shadow duration-200 overflow-hidden">
+    <div
+      data-testid="postCard"
+      className="bg-white rounded-lg shadow-sm border border-gray-200 hover:shadow-md transition-shadow duration-200 overflow-hidden"
+    >
       <div className="p-6">
         <div className="flex items-start justify-between mb-4">
           <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Tests
  * Strengthened end-to-end coverage for post interactions (create, edit, cancel, delete) using card-scoped targeting to improve reliability and reduce flakiness.
* Chores
  * Added stable identifiers to post cards to support precise test targeting; no impact on UI or behavior.
* No User-Facing Changes
  * Interface and functionality remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->