### PR TITLE
Implement DB-backed signup; add users table and duplicate UID handling

### DIFF
--- a/packages/backend_app/src/apps/user/index.test.ts
+++ b/packages/backend_app/src/apps/user/index.test.ts
@@ -4,6 +4,7 @@ import { testClient } from "hono/testing";
 import { app } from "../../apps";
 import { db } from "../../db";
 import { usersTable } from "../../db/schema";
+import { supabaseUid } from "../../test/supabase";
 
 describe("userApp", () => {
   describe("signupRoute", () => {
@@ -27,7 +28,7 @@ describe("userApp", () => {
 
       const user = users[0];
       if (!user) throw new Error("user is not found");
-      expect(user.supabase_uid).toBe("11111111-1111-1111-1111-111111111111");
+      expect(user.supabase_uid).toBe(supabaseUid);
     });
 
     describe("when Authorization header is not provided", () => {
@@ -38,6 +39,17 @@ describe("userApp", () => {
       it("should return 401 Response", async () => {
         const res = await subject();
         expect(res.status).toBe(401);
+      });
+    });
+
+    describe("when supabase_uid is already registered", () => {
+      beforeEach(async () => {
+        await db.insert(usersTable).values({ supabase_uid: supabaseUid });
+      });
+
+      it("should return 500 Response", async () => {
+        const res = await subject();
+        expect(res.status).toBe(500);
       });
     });
   });

--- a/packages/backend_app/src/apps/user/index.test.ts
+++ b/packages/backend_app/src/apps/user/index.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it } from "bun:test";
 import type { ClientRequestOptions } from "hono/client";
 import { testClient } from "hono/testing";
 import { app } from "../../apps";
+import { db } from "../../db";
+import { usersTable } from "../../db/schema";
 
 describe("userApp", () => {
   describe("signupRoute", () => {
@@ -19,6 +21,13 @@ describe("userApp", () => {
     it("should return 200 Response", async () => {
       const res = await subject();
       expect(res.status).toBe(200);
+
+      const users = await db.select().from(usersTable);
+      expect(users).toHaveLength(1);
+
+      const user = users[0];
+      if (!user) throw new Error("user is not found");
+      expect(user.supabase_uid).toBe("11111111-1111-1111-1111-111111111111");
     });
 
     describe("when Authorization header is not provided", () => {

--- a/packages/backend_app/src/apps/user/index.test.ts
+++ b/packages/backend_app/src/apps/user/index.test.ts
@@ -47,9 +47,16 @@ describe("userApp", () => {
         await db.insert(usersTable).values({ supabase_uid: supabaseUid });
       });
 
-      it("should return 500 Response", async () => {
+      it("should return 200 Response", async () => {
         const res = await subject();
-        expect(res.status).toBe(500);
+        expect(res.status).toBe(200);
+
+        const users = await db.select().from(usersTable);
+        expect(users).toHaveLength(1);
+
+        const user = users[0];
+        if (!user) throw new Error("user is not found");
+        expect(user.supabase_uid).toBe(supabaseUid);
       });
     });
   });

--- a/packages/backend_app/src/apps/user/index.ts
+++ b/packages/backend_app/src/apps/user/index.ts
@@ -1,3 +1,5 @@
+import { db } from "../../db";
+import { usersTable } from "../../db/schema";
 import { jwtMiddleware } from "../../middlewares/jwt";
 import { createApp } from "../factory";
 import { signupRoute } from "./route";
@@ -13,8 +15,9 @@ userApp.openAPIRegistry.registerComponent("securitySchemes", "bearerAuth", {
 userApp.use(jwtMiddleware);
 
 const routes = userApp.openapi(signupRoute, async (c) => {
-  // TODO: ユーザー登録
-  return c.json({ status: "ok" }, 200);
+  const { sub: supabase_uid } = c.get("jwtClaims");
+  await db.insert(usersTable).values({ supabase_uid });
+  return c.json(null, 200);
 });
 
 export { routes as userApp };

--- a/packages/backend_app/src/apps/user/index.ts
+++ b/packages/backend_app/src/apps/user/index.ts
@@ -16,7 +16,10 @@ userApp.use(jwtMiddleware);
 
 const routes = userApp.openapi(signupRoute, async (c) => {
   const { sub: supabase_uid } = c.get("jwtClaims");
-  await db.insert(usersTable).values({ supabase_uid });
+  await db
+    .insert(usersTable)
+    .values({ supabase_uid })
+    .onConflictDoNothing({ target: usersTable.supabase_uid });
   return c.json(null, 200);
 });
 

--- a/packages/backend_app/src/db/schema.ts
+++ b/packages/backend_app/src/db/schema.ts
@@ -14,7 +14,7 @@ const timestamps = {
 
 export const usersTable = pgTable("users", {
   ...primaryKeys,
-  supabase_uid: uuid().notNull(),
+  supabase_uid: uuid().unique().notNull(),
   ...timestamps,
 });
 

--- a/packages/backend_app/src/db/schema.ts
+++ b/packages/backend_app/src/db/schema.ts
@@ -1,4 +1,8 @@
-import { integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { integer, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+
+const primaryKeys = {
+  id: integer().primaryKey().generatedAlwaysAsIdentity(),
+};
 
 const timestamps = {
   created_at: timestamp().defaultNow().notNull(),
@@ -8,8 +12,14 @@ const timestamps = {
     .$onUpdate(() => new Date()),
 };
 
+export const usersTable = pgTable("users", {
+  ...primaryKeys,
+  supabase_uid: uuid().notNull(),
+  ...timestamps,
+});
+
 export const postsTable = pgTable("posts", {
-  id: integer().primaryKey().generatedAlwaysAsIdentity(),
+  ...primaryKeys,
   content: text().notNull(),
   ...timestamps,
 });

--- a/packages/backend_app/src/test/supabase.ts
+++ b/packages/backend_app/src/test/supabase.ts
@@ -1,6 +1,8 @@
 import { mock } from "bun:test";
 import type { GoTrueClient } from "@supabase/supabase-js";
 
+export const supabaseUid = "11111111-1111-1111-1111-111111111111";
+
 // https://supabase.com/docs/reference/javascript/auth-getclaims
 export const getClaims = mock(
   async (): ReturnType<GoTrueClient["getClaims"]> => {
@@ -23,7 +25,7 @@ export const getClaims = mock(
           iss: "https://project-id.supabase.co/auth/v1",
           phone: "+13334445555",
           role: "authenticated",
-          session_id: "11111111-1111-1111-1111-111111111111",
+          session_id: supabaseUid,
           sub: "11111111-1111-1111-1111-111111111111",
           user_metadata: {},
         },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Signup now persists new user accounts in a dedicated users table.

* Bug Fixes
  * Signup ignores duplicate user inserts and returns an error when the unique user identifier is already registered.

* Tests
  * Expanded signup tests to verify DB persistence, handle duplicate-account scenario, and cover success and missing-authorization cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->