### PR TITLE
Add 403 Forbidden and ownership checks, update API spec and client

### DIFF
--- a/.github/workflows/frontend-app.yml
+++ b/.github/workflows/frontend-app.yml
@@ -40,7 +40,6 @@ jobs:
             frontend:
               - '.github/workflows/frontend-app.yml'
               - 'packages/frontend_app/**'
-              - '!packages/frontend_app/src/client/**'
               - '.tool-versions'
               - 'biome.jsonc'
               - 'tsconfig.json'

--- a/packages/backend_app/openapi.json
+++ b/packages/backend_app/openapi.json
@@ -18,6 +18,7 @@
             "enum": [
               "Bad Request",
               "Unauthorized",
+              "Forbidden",
               "Not Found",
               "Internal Server Error"
             ],
@@ -94,10 +95,42 @@
                           "enum": [
                             "Bad Request",
                             "Unauthorized",
+                            "Forbidden",
                             "Not Found",
                             "Internal Server Error"
                           ],
                           "example": "Unauthorized"
+                        },
+                        "message": {
+                          "type": "string",
+                          "description": "explanation"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    { "$ref": "#/components/schemas/ErrorResponse" },
+                    {
+                      "properties": {
+                        "code": {
+                          "type": "string",
+                          "enum": [
+                            "Bad Request",
+                            "Unauthorized",
+                            "Forbidden",
+                            "Not Found",
+                            "Internal Server Error"
+                          ],
+                          "example": "Forbidden"
                         },
                         "message": {
                           "type": "string",
@@ -124,6 +157,7 @@
                           "enum": [
                             "Bad Request",
                             "Unauthorized",
+                            "Forbidden",
                             "Not Found",
                             "Internal Server Error"
                           ],
@@ -154,6 +188,7 @@
                           "enum": [
                             "Bad Request",
                             "Unauthorized",
+                            "Forbidden",
                             "Not Found",
                             "Internal Server Error"
                           ],
@@ -216,10 +251,42 @@
                           "enum": [
                             "Bad Request",
                             "Unauthorized",
+                            "Forbidden",
                             "Not Found",
                             "Internal Server Error"
                           ],
                           "example": "Unauthorized"
+                        },
+                        "message": {
+                          "type": "string",
+                          "description": "explanation"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    { "$ref": "#/components/schemas/ErrorResponse" },
+                    {
+                      "properties": {
+                        "code": {
+                          "type": "string",
+                          "enum": [
+                            "Bad Request",
+                            "Unauthorized",
+                            "Forbidden",
+                            "Not Found",
+                            "Internal Server Error"
+                          ],
+                          "example": "Forbidden"
                         },
                         "message": {
                           "type": "string",
@@ -246,6 +313,7 @@
                           "enum": [
                             "Bad Request",
                             "Unauthorized",
+                            "Forbidden",
                             "Not Found",
                             "Internal Server Error"
                           ],
@@ -276,6 +344,7 @@
                           "enum": [
                             "Bad Request",
                             "Unauthorized",
+                            "Forbidden",
                             "Not Found",
                             "Internal Server Error"
                           ],
@@ -352,10 +421,42 @@
                           "enum": [
                             "Bad Request",
                             "Unauthorized",
+                            "Forbidden",
                             "Not Found",
                             "Internal Server Error"
                           ],
                           "example": "Unauthorized"
+                        },
+                        "message": {
+                          "type": "string",
+                          "description": "explanation"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    { "$ref": "#/components/schemas/ErrorResponse" },
+                    {
+                      "properties": {
+                        "code": {
+                          "type": "string",
+                          "enum": [
+                            "Bad Request",
+                            "Unauthorized",
+                            "Forbidden",
+                            "Not Found",
+                            "Internal Server Error"
+                          ],
+                          "example": "Forbidden"
                         },
                         "message": {
                           "type": "string",
@@ -382,6 +483,7 @@
                           "enum": [
                             "Bad Request",
                             "Unauthorized",
+                            "Forbidden",
                             "Not Found",
                             "Internal Server Error"
                           ],
@@ -412,6 +514,7 @@
                           "enum": [
                             "Bad Request",
                             "Unauthorized",
+                            "Forbidden",
                             "Not Found",
                             "Internal Server Error"
                           ],
@@ -501,10 +604,42 @@
                           "enum": [
                             "Bad Request",
                             "Unauthorized",
+                            "Forbidden",
                             "Not Found",
                             "Internal Server Error"
                           ],
                           "example": "Unauthorized"
+                        },
+                        "message": {
+                          "type": "string",
+                          "description": "explanation"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    { "$ref": "#/components/schemas/ErrorResponse" },
+                    {
+                      "properties": {
+                        "code": {
+                          "type": "string",
+                          "enum": [
+                            "Bad Request",
+                            "Unauthorized",
+                            "Forbidden",
+                            "Not Found",
+                            "Internal Server Error"
+                          ],
+                          "example": "Forbidden"
                         },
                         "message": {
                           "type": "string",
@@ -531,6 +666,7 @@
                           "enum": [
                             "Bad Request",
                             "Unauthorized",
+                            "Forbidden",
                             "Not Found",
                             "Internal Server Error"
                           ],
@@ -561,6 +697,7 @@
                           "enum": [
                             "Bad Request",
                             "Unauthorized",
+                            "Forbidden",
                             "Not Found",
                             "Internal Server Error"
                           ],
@@ -618,10 +755,42 @@
                           "enum": [
                             "Bad Request",
                             "Unauthorized",
+                            "Forbidden",
                             "Not Found",
                             "Internal Server Error"
                           ],
                           "example": "Unauthorized"
+                        },
+                        "message": {
+                          "type": "string",
+                          "description": "explanation"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    { "$ref": "#/components/schemas/ErrorResponse" },
+                    {
+                      "properties": {
+                        "code": {
+                          "type": "string",
+                          "enum": [
+                            "Bad Request",
+                            "Unauthorized",
+                            "Forbidden",
+                            "Not Found",
+                            "Internal Server Error"
+                          ],
+                          "example": "Forbidden"
                         },
                         "message": {
                           "type": "string",
@@ -648,6 +817,7 @@
                           "enum": [
                             "Bad Request",
                             "Unauthorized",
+                            "Forbidden",
                             "Not Found",
                             "Internal Server Error"
                           ],
@@ -678,6 +848,7 @@
                           "enum": [
                             "Bad Request",
                             "Unauthorized",
+                            "Forbidden",
                             "Not Found",
                             "Internal Server Error"
                           ],

--- a/packages/backend_app/src/apps/context.ts
+++ b/packages/backend_app/src/apps/context.ts
@@ -1,11 +1,13 @@
 import type { JwtPayload } from "@supabase/supabase-js";
 import { getContext } from "hono/context-storage";
+import type { usersTable } from "../db/schema";
 
 export type HonoEnv = {
   Variables: {
     requestId: string;
     jwtToken: string;
     jwtClaims: JwtPayload;
+    user: typeof usersTable.$inferSelect;
   };
 };
 

--- a/packages/backend_app/src/apps/posts/index.test.ts
+++ b/packages/backend_app/src/apps/posts/index.test.ts
@@ -10,19 +10,30 @@ import { supabaseUid } from "../../test/supabase";
 describe("postsApp", () => {
   let headers: ClientRequestOptions["headers"];
   let user: typeof usersTable.$inferSelect;
+  let anotherUser: typeof usersTable.$inferSelect;
 
   beforeEach(() => {
     headers = { Authorization: "Bearer test" };
   });
 
   beforeEach(async () => {
-    const users = await db
-      .insert(usersTable)
-      .values({ supabase_uid: supabaseUid })
-      .returning();
-    const createdUser = users[0];
-    if (!createdUser) throw new Error("user is not found");
-    user = createdUser;
+    const _user = (
+      await db
+        .insert(usersTable)
+        .values({ supabase_uid: supabaseUid })
+        .returning()
+    )[0];
+    if (!_user) throw new Error("user is not found");
+    user = _user;
+
+    const _anotherUser = (
+      await db
+        .insert(usersTable)
+        .values({ supabase_uid: faker.string.uuid() })
+        .returning()
+    )[0];
+    if (!_anotherUser) throw new Error("another user is not found");
+    anotherUser = _anotherUser;
   });
 
   describe("getPostsRoute", () => {
@@ -188,13 +199,6 @@ describe("postsApp", () => {
 
       describe("when post user is not the same as the current user", () => {
         beforeEach(async () => {
-          const anotherUser = (
-            await db
-              .insert(usersTable)
-              .values({ supabase_uid: faker.string.uuid() })
-              .returning()
-          )[0];
-          if (!anotherUser) throw new Error("another user is not found");
           await db
             .insert(postsTable)
             .values({ user_id: anotherUser.id, content: "test" });
@@ -275,6 +279,19 @@ describe("postsApp", () => {
 
           const posts = await db.select().from(postsTable);
           expect(posts).toHaveLength(0);
+        });
+      });
+
+      describe("when post user is not the same as the current user", () => {
+        beforeEach(async () => {
+          await db
+            .insert(postsTable)
+            .values({ user_id: anotherUser.id, content: "test" });
+        });
+
+        it("should return 403 Response", async () => {
+          const res = await subject();
+          expect(res.status).toBe(403);
         });
       });
     });

--- a/packages/backend_app/src/dto/output/error.ts
+++ b/packages/backend_app/src/dto/output/error.ts
@@ -3,6 +3,7 @@ import { z } from "@hono/zod-openapi";
 const errorCodes = [
   "Bad Request",
   "Unauthorized",
+  "Forbidden",
   "Not Found",
   "Internal Server Error",
 ] as const;
@@ -31,6 +32,7 @@ export const ErrorResponses = {
       },
     },
   },
+
   401: {
     description: "Unauthorized",
     content: {
@@ -39,6 +41,16 @@ export const ErrorResponses = {
       },
     },
   },
+
+  403: {
+    description: "Forbidden",
+    content: {
+      "application/json": {
+        schema: errorSchemaFactory("Forbidden"),
+      },
+    },
+  },
+
   404: {
     description: "Not Found",
     content: {
@@ -47,6 +59,7 @@ export const ErrorResponses = {
       },
     },
   },
+
   500: {
     description: "Internal Server Error",
     content: {

--- a/packages/backend_app/src/middlewares/user/index.test.ts
+++ b/packages/backend_app/src/middlewares/user/index.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { Hono } from "hono";
+import type { ClientRequestOptions } from "hono/client";
+import { testClient } from "hono/testing";
+import type { ErrorResponse } from "../../dto/output/error";
+import { userMiddleware } from ".";
+
+describe("userMiddleware", () => {
+  let header: ClientRequestOptions["headers"];
+
+  const subject = async () => {
+    const app = new Hono();
+    app.use(userMiddleware);
+    const routes = app.get("/", (c) =>
+      c.json<{ message: string } | ErrorResponse>({ message: "Hello Hono!" }),
+    );
+    return testClient(routes).index.$get({ header });
+  };
+
+  beforeEach(() => {
+    header = { Authorization: "Bearer test" };
+  });
+
+  it("should return 200 Response", async () => {
+    const res = await subject();
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/backend_app/src/middlewares/user/index.test.ts
+++ b/packages/backend_app/src/middlewares/user/index.test.ts
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, it } from "bun:test";
 import { Hono } from "hono";
 import type { ClientRequestOptions } from "hono/client";
 import { testClient } from "hono/testing";
+import { db } from "../../db";
+import { usersTable } from "../../db/schema";
 import type { ErrorResponse } from "../../dto/output/error";
+import { supabaseUid } from "../../test/supabase";
 import { userMiddleware } from ".";
 
 describe("userMiddleware", () => {
@@ -21,8 +24,19 @@ describe("userMiddleware", () => {
     header = { Authorization: "Bearer test" };
   });
 
-  it("should return 200 Response", async () => {
+  it("should return 401 Response", async () => {
     const res = await subject();
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(401);
+  });
+
+  describe("when user is found", () => {
+    beforeEach(async () => {
+      await db.insert(usersTable).values({ supabase_uid: supabaseUid });
+    });
+
+    it("should return 200 Response", async () => {
+      const res = await subject();
+      expect(res.status).toBe(200);
+    });
   });
 });

--- a/packages/backend_app/src/middlewares/user/index.ts
+++ b/packages/backend_app/src/middlewares/user/index.ts
@@ -1,0 +1,30 @@
+import { eq } from "drizzle-orm";
+import { every } from "hono/combine";
+import { createMiddleware } from "hono/factory";
+import type { HonoEnv } from "../../apps/context";
+import { db } from "../../db";
+import { usersTable } from "../../db/schema";
+import type { ErrorResponse } from "../../dto/output/error";
+import { jwtMiddleware } from "../jwt";
+
+const baseUserMiddleware = createMiddleware<HonoEnv>(async (c, next) => {
+  const { sub: supabase_uid } = c.get("jwtClaims");
+  const user = (
+    await db
+      .select()
+      .from(usersTable)
+      .where(eq(usersTable.supabase_uid, supabase_uid))
+  )[0];
+
+  if (!user) {
+    return c.json<ErrorResponse>(
+      { code: "Unauthorized", message: "User not found" },
+      401,
+    );
+  }
+
+  c.set("user", user);
+  await next();
+});
+
+export const userMiddleware = every(jwtMiddleware, baseUserMiddleware);

--- a/packages/backend_app/src/middlewares/user/index.ts
+++ b/packages/backend_app/src/middlewares/user/index.ts
@@ -8,12 +8,12 @@ import type { ErrorResponse } from "../../dto/output/error";
 import { jwtMiddleware } from "../jwt";
 
 const baseUserMiddleware = createMiddleware<HonoEnv>(async (c, next) => {
-  const { sub: supabase_uid } = c.get("jwtClaims");
+  const { sub: supabaseUid } = c.get("jwtClaims");
   const user = (
     await db
       .select()
       .from(usersTable)
-      .where(eq(usersTable.supabase_uid, supabase_uid))
+      .where(eq(usersTable.supabase_uid, supabaseUid))
   )[0];
 
   if (!user) {

--- a/packages/frontend_app/src/client/index.schemas.ts
+++ b/packages/frontend_app/src/client/index.schemas.ts
@@ -11,6 +11,7 @@ export type ErrorResponseCode =
 export const ErrorResponseCode = {
   Bad_Request: "Bad Request",
   Unauthorized: "Unauthorized",
+  Forbidden: "Forbidden",
   Not_Found: "Not Found",
   Internal_Server_Error: "Internal Server Error",
 } as const;
@@ -48,6 +49,7 @@ export type PostUserSignup401AllOfCode =
 export const PostUserSignup401AllOfCode = {
   Bad_Request: "Bad Request",
   Unauthorized: "Unauthorized",
+  Forbidden: "Forbidden",
   Not_Found: "Not Found",
   Internal_Server_Error: "Internal Server Error",
 } as const;
@@ -60,6 +62,26 @@ export type PostUserSignup401AllOf = {
 
 export type PostUserSignup401 = ErrorResponse & PostUserSignup401AllOf;
 
+export type PostUserSignup403AllOfCode =
+  (typeof PostUserSignup403AllOfCode)[keyof typeof PostUserSignup403AllOfCode];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PostUserSignup403AllOfCode = {
+  Bad_Request: "Bad Request",
+  Unauthorized: "Unauthorized",
+  Forbidden: "Forbidden",
+  Not_Found: "Not Found",
+  Internal_Server_Error: "Internal Server Error",
+} as const;
+
+export type PostUserSignup403AllOf = {
+  code?: PostUserSignup403AllOfCode;
+  /** explanation */
+  message?: string;
+};
+
+export type PostUserSignup403 = ErrorResponse & PostUserSignup403AllOf;
+
 export type PostUserSignup404AllOfCode =
   (typeof PostUserSignup404AllOfCode)[keyof typeof PostUserSignup404AllOfCode];
 
@@ -67,6 +89,7 @@ export type PostUserSignup404AllOfCode =
 export const PostUserSignup404AllOfCode = {
   Bad_Request: "Bad Request",
   Unauthorized: "Unauthorized",
+  Forbidden: "Forbidden",
   Not_Found: "Not Found",
   Internal_Server_Error: "Internal Server Error",
 } as const;
@@ -86,6 +109,7 @@ export type PostUserSignup500AllOfCode =
 export const PostUserSignup500AllOfCode = {
   Bad_Request: "Bad Request",
   Unauthorized: "Unauthorized",
+  Forbidden: "Forbidden",
   Not_Found: "Not Found",
   Internal_Server_Error: "Internal Server Error",
 } as const;
@@ -109,6 +133,7 @@ export type GetPosts401AllOfCode =
 export const GetPosts401AllOfCode = {
   Bad_Request: "Bad Request",
   Unauthorized: "Unauthorized",
+  Forbidden: "Forbidden",
   Not_Found: "Not Found",
   Internal_Server_Error: "Internal Server Error",
 } as const;
@@ -121,6 +146,26 @@ export type GetPosts401AllOf = {
 
 export type GetPosts401 = ErrorResponse & GetPosts401AllOf;
 
+export type GetPosts403AllOfCode =
+  (typeof GetPosts403AllOfCode)[keyof typeof GetPosts403AllOfCode];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const GetPosts403AllOfCode = {
+  Bad_Request: "Bad Request",
+  Unauthorized: "Unauthorized",
+  Forbidden: "Forbidden",
+  Not_Found: "Not Found",
+  Internal_Server_Error: "Internal Server Error",
+} as const;
+
+export type GetPosts403AllOf = {
+  code?: GetPosts403AllOfCode;
+  /** explanation */
+  message?: string;
+};
+
+export type GetPosts403 = ErrorResponse & GetPosts403AllOf;
+
 export type GetPosts404AllOfCode =
   (typeof GetPosts404AllOfCode)[keyof typeof GetPosts404AllOfCode];
 
@@ -128,6 +173,7 @@ export type GetPosts404AllOfCode =
 export const GetPosts404AllOfCode = {
   Bad_Request: "Bad Request",
   Unauthorized: "Unauthorized",
+  Forbidden: "Forbidden",
   Not_Found: "Not Found",
   Internal_Server_Error: "Internal Server Error",
 } as const;
@@ -147,6 +193,7 @@ export type GetPosts500AllOfCode =
 export const GetPosts500AllOfCode = {
   Bad_Request: "Bad Request",
   Unauthorized: "Unauthorized",
+  Forbidden: "Forbidden",
   Not_Found: "Not Found",
   Internal_Server_Error: "Internal Server Error",
 } as const;
@@ -178,6 +225,7 @@ export type PostPosts401AllOfCode =
 export const PostPosts401AllOfCode = {
   Bad_Request: "Bad Request",
   Unauthorized: "Unauthorized",
+  Forbidden: "Forbidden",
   Not_Found: "Not Found",
   Internal_Server_Error: "Internal Server Error",
 } as const;
@@ -190,6 +238,26 @@ export type PostPosts401AllOf = {
 
 export type PostPosts401 = ErrorResponse & PostPosts401AllOf;
 
+export type PostPosts403AllOfCode =
+  (typeof PostPosts403AllOfCode)[keyof typeof PostPosts403AllOfCode];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PostPosts403AllOfCode = {
+  Bad_Request: "Bad Request",
+  Unauthorized: "Unauthorized",
+  Forbidden: "Forbidden",
+  Not_Found: "Not Found",
+  Internal_Server_Error: "Internal Server Error",
+} as const;
+
+export type PostPosts403AllOf = {
+  code?: PostPosts403AllOfCode;
+  /** explanation */
+  message?: string;
+};
+
+export type PostPosts403 = ErrorResponse & PostPosts403AllOf;
+
 export type PostPosts404AllOfCode =
   (typeof PostPosts404AllOfCode)[keyof typeof PostPosts404AllOfCode];
 
@@ -197,6 +265,7 @@ export type PostPosts404AllOfCode =
 export const PostPosts404AllOfCode = {
   Bad_Request: "Bad Request",
   Unauthorized: "Unauthorized",
+  Forbidden: "Forbidden",
   Not_Found: "Not Found",
   Internal_Server_Error: "Internal Server Error",
 } as const;
@@ -216,6 +285,7 @@ export type PostPosts500AllOfCode =
 export const PostPosts500AllOfCode = {
   Bad_Request: "Bad Request",
   Unauthorized: "Unauthorized",
+  Forbidden: "Forbidden",
   Not_Found: "Not Found",
   Internal_Server_Error: "Internal Server Error",
 } as const;
@@ -247,6 +317,7 @@ export type PutPostsId401AllOfCode =
 export const PutPostsId401AllOfCode = {
   Bad_Request: "Bad Request",
   Unauthorized: "Unauthorized",
+  Forbidden: "Forbidden",
   Not_Found: "Not Found",
   Internal_Server_Error: "Internal Server Error",
 } as const;
@@ -259,6 +330,26 @@ export type PutPostsId401AllOf = {
 
 export type PutPostsId401 = ErrorResponse & PutPostsId401AllOf;
 
+export type PutPostsId403AllOfCode =
+  (typeof PutPostsId403AllOfCode)[keyof typeof PutPostsId403AllOfCode];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PutPostsId403AllOfCode = {
+  Bad_Request: "Bad Request",
+  Unauthorized: "Unauthorized",
+  Forbidden: "Forbidden",
+  Not_Found: "Not Found",
+  Internal_Server_Error: "Internal Server Error",
+} as const;
+
+export type PutPostsId403AllOf = {
+  code?: PutPostsId403AllOfCode;
+  /** explanation */
+  message?: string;
+};
+
+export type PutPostsId403 = ErrorResponse & PutPostsId403AllOf;
+
 export type PutPostsId404AllOfCode =
   (typeof PutPostsId404AllOfCode)[keyof typeof PutPostsId404AllOfCode];
 
@@ -266,6 +357,7 @@ export type PutPostsId404AllOfCode =
 export const PutPostsId404AllOfCode = {
   Bad_Request: "Bad Request",
   Unauthorized: "Unauthorized",
+  Forbidden: "Forbidden",
   Not_Found: "Not Found",
   Internal_Server_Error: "Internal Server Error",
 } as const;
@@ -285,6 +377,7 @@ export type PutPostsId500AllOfCode =
 export const PutPostsId500AllOfCode = {
   Bad_Request: "Bad Request",
   Unauthorized: "Unauthorized",
+  Forbidden: "Forbidden",
   Not_Found: "Not Found",
   Internal_Server_Error: "Internal Server Error",
 } as const;
@@ -304,6 +397,7 @@ export type DeletePostsId401AllOfCode =
 export const DeletePostsId401AllOfCode = {
   Bad_Request: "Bad Request",
   Unauthorized: "Unauthorized",
+  Forbidden: "Forbidden",
   Not_Found: "Not Found",
   Internal_Server_Error: "Internal Server Error",
 } as const;
@@ -316,6 +410,26 @@ export type DeletePostsId401AllOf = {
 
 export type DeletePostsId401 = ErrorResponse & DeletePostsId401AllOf;
 
+export type DeletePostsId403AllOfCode =
+  (typeof DeletePostsId403AllOfCode)[keyof typeof DeletePostsId403AllOfCode];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const DeletePostsId403AllOfCode = {
+  Bad_Request: "Bad Request",
+  Unauthorized: "Unauthorized",
+  Forbidden: "Forbidden",
+  Not_Found: "Not Found",
+  Internal_Server_Error: "Internal Server Error",
+} as const;
+
+export type DeletePostsId403AllOf = {
+  code?: DeletePostsId403AllOfCode;
+  /** explanation */
+  message?: string;
+};
+
+export type DeletePostsId403 = ErrorResponse & DeletePostsId403AllOf;
+
 export type DeletePostsId404AllOfCode =
   (typeof DeletePostsId404AllOfCode)[keyof typeof DeletePostsId404AllOfCode];
 
@@ -323,6 +437,7 @@ export type DeletePostsId404AllOfCode =
 export const DeletePostsId404AllOfCode = {
   Bad_Request: "Bad Request",
   Unauthorized: "Unauthorized",
+  Forbidden: "Forbidden",
   Not_Found: "Not Found",
   Internal_Server_Error: "Internal Server Error",
 } as const;
@@ -342,6 +457,7 @@ export type DeletePostsId500AllOfCode =
 export const DeletePostsId500AllOfCode = {
   Bad_Request: "Bad Request",
   Unauthorized: "Unauthorized",
+  Forbidden: "Forbidden",
   Not_Found: "Not Found",
   Internal_Server_Error: "Internal Server Error",
 } as const;

--- a/packages/frontend_app/src/client/index.ts
+++ b/packages/frontend_app/src/client/index.ts
@@ -25,23 +25,28 @@ import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { customFetch } from "../lib/custom-fetch";
 import type {
   DeletePostsId401,
+  DeletePostsId403,
   DeletePostsId404,
   DeletePostsId500,
   ErrorResponse,
   GetPosts200,
   GetPosts401,
+  GetPosts403,
   GetPosts404,
   GetPosts500,
   PostPosts200,
   PostPosts401,
+  PostPosts403,
   PostPosts404,
   PostPosts500,
   PostPostsBody,
   PostUserSignup401,
+  PostUserSignup403,
   PostUserSignup404,
   PostUserSignup500,
   PutPostsId200,
   PutPostsId401,
+  PutPostsId403,
   PutPostsId404,
   PutPostsId500,
   PutPostsIdBody,
@@ -68,6 +73,11 @@ export type postUserSignupResponse401 = {
   status: 401;
 };
 
+export type postUserSignupResponse403 = {
+  data: PostUserSignup403;
+  status: 403;
+};
+
 export type postUserSignupResponse404 = {
   data: PostUserSignup404;
   status: 404;
@@ -82,6 +92,7 @@ export type postUserSignupResponseComposite =
   | postUserSignupResponse200
   | postUserSignupResponse400
   | postUserSignupResponse401
+  | postUserSignupResponse403
   | postUserSignupResponse404
   | postUserSignupResponse500;
 
@@ -106,6 +117,7 @@ export const getPostUserSignupMutationOptions = <
   TError =
     | ErrorResponse
     | PostUserSignup401
+    | PostUserSignup403
     | PostUserSignup404
     | PostUserSignup500,
   TContext = unknown,
@@ -149,6 +161,7 @@ export type PostUserSignupMutationResult = NonNullable<
 export type PostUserSignupMutationError =
   | ErrorResponse
   | PostUserSignup401
+  | PostUserSignup403
   | PostUserSignup404
   | PostUserSignup500;
 
@@ -156,6 +169,7 @@ export const usePostUserSignup = <
   TError =
     | ErrorResponse
     | PostUserSignup401
+    | PostUserSignup403
     | PostUserSignup404
     | PostUserSignup500,
   TContext = unknown,
@@ -196,6 +210,11 @@ export type getPostsResponse401 = {
   status: 401;
 };
 
+export type getPostsResponse403 = {
+  data: GetPosts403;
+  status: 403;
+};
+
 export type getPostsResponse404 = {
   data: GetPosts404;
   status: 404;
@@ -210,6 +229,7 @@ export type getPostsResponseComposite =
   | getPostsResponse200
   | getPostsResponse400
   | getPostsResponse401
+  | getPostsResponse403
   | getPostsResponse404
   | getPostsResponse500;
 
@@ -236,7 +256,12 @@ export const getGetPostsQueryKey = () => {
 
 export const getGetPostsQueryOptions = <
   TData = Awaited<ReturnType<typeof getPosts>>,
-  TError = ErrorResponse | GetPosts401 | GetPosts404 | GetPosts500,
+  TError =
+    | ErrorResponse
+    | GetPosts401
+    | GetPosts403
+    | GetPosts404
+    | GetPosts500,
 >(options?: {
   query?: Partial<
     UseQueryOptions<Awaited<ReturnType<typeof getPosts>>, TError, TData>
@@ -264,12 +289,18 @@ export type GetPostsQueryResult = NonNullable<
 export type GetPostsQueryError =
   | ErrorResponse
   | GetPosts401
+  | GetPosts403
   | GetPosts404
   | GetPosts500;
 
 export function useGetPosts<
   TData = Awaited<ReturnType<typeof getPosts>>,
-  TError = ErrorResponse | GetPosts401 | GetPosts404 | GetPosts500,
+  TError =
+    | ErrorResponse
+    | GetPosts401
+    | GetPosts403
+    | GetPosts404
+    | GetPosts500,
 >(
   options: {
     query: Partial<
@@ -291,7 +322,12 @@ export function useGetPosts<
 };
 export function useGetPosts<
   TData = Awaited<ReturnType<typeof getPosts>>,
-  TError = ErrorResponse | GetPosts401 | GetPosts404 | GetPosts500,
+  TError =
+    | ErrorResponse
+    | GetPosts401
+    | GetPosts403
+    | GetPosts404
+    | GetPosts500,
 >(
   options?: {
     query?: Partial<
@@ -313,7 +349,12 @@ export function useGetPosts<
 };
 export function useGetPosts<
   TData = Awaited<ReturnType<typeof getPosts>>,
-  TError = ErrorResponse | GetPosts401 | GetPosts404 | GetPosts500,
+  TError =
+    | ErrorResponse
+    | GetPosts401
+    | GetPosts403
+    | GetPosts404
+    | GetPosts500,
 >(
   options?: {
     query?: Partial<
@@ -328,7 +369,12 @@ export function useGetPosts<
 
 export function useGetPosts<
   TData = Awaited<ReturnType<typeof getPosts>>,
-  TError = ErrorResponse | GetPosts401 | GetPosts404 | GetPosts500,
+  TError =
+    | ErrorResponse
+    | GetPosts401
+    | GetPosts403
+    | GetPosts404
+    | GetPosts500,
 >(
   options?: {
     query?: Partial<
@@ -354,7 +400,12 @@ export function useGetPosts<
 
 export const prefetchGetPostsQuery = async <
   TData = Awaited<ReturnType<typeof getPosts>>,
-  TError = ErrorResponse | GetPosts401 | GetPosts404 | GetPosts500,
+  TError =
+    | ErrorResponse
+    | GetPosts401
+    | GetPosts403
+    | GetPosts404
+    | GetPosts500,
 >(
   queryClient: QueryClient,
   options?: {
@@ -373,7 +424,12 @@ export const prefetchGetPostsQuery = async <
 
 export const getGetPostsSuspenseQueryOptions = <
   TData = Awaited<ReturnType<typeof getPosts>>,
-  TError = ErrorResponse | GetPosts401 | GetPosts404 | GetPosts500,
+  TError =
+    | ErrorResponse
+    | GetPosts401
+    | GetPosts403
+    | GetPosts404
+    | GetPosts500,
 >(options?: {
   query?: Partial<
     UseSuspenseQueryOptions<Awaited<ReturnType<typeof getPosts>>, TError, TData>
@@ -401,12 +457,18 @@ export type GetPostsSuspenseQueryResult = NonNullable<
 export type GetPostsSuspenseQueryError =
   | ErrorResponse
   | GetPosts401
+  | GetPosts403
   | GetPosts404
   | GetPosts500;
 
 export function useGetPostsSuspense<
   TData = Awaited<ReturnType<typeof getPosts>>,
-  TError = ErrorResponse | GetPosts401 | GetPosts404 | GetPosts500,
+  TError =
+    | ErrorResponse
+    | GetPosts401
+    | GetPosts403
+    | GetPosts404
+    | GetPosts500,
 >(
   options: {
     query: Partial<
@@ -424,7 +486,12 @@ export function useGetPostsSuspense<
 };
 export function useGetPostsSuspense<
   TData = Awaited<ReturnType<typeof getPosts>>,
-  TError = ErrorResponse | GetPosts401 | GetPosts404 | GetPosts500,
+  TError =
+    | ErrorResponse
+    | GetPosts401
+    | GetPosts403
+    | GetPosts404
+    | GetPosts500,
 >(
   options?: {
     query?: Partial<
@@ -442,7 +509,12 @@ export function useGetPostsSuspense<
 };
 export function useGetPostsSuspense<
   TData = Awaited<ReturnType<typeof getPosts>>,
-  TError = ErrorResponse | GetPosts401 | GetPosts404 | GetPosts500,
+  TError =
+    | ErrorResponse
+    | GetPosts401
+    | GetPosts403
+    | GetPosts404
+    | GetPosts500,
 >(
   options?: {
     query?: Partial<
@@ -461,7 +533,12 @@ export function useGetPostsSuspense<
 
 export function useGetPostsSuspense<
   TData = Awaited<ReturnType<typeof getPosts>>,
-  TError = ErrorResponse | GetPosts401 | GetPosts404 | GetPosts500,
+  TError =
+    | ErrorResponse
+    | GetPosts401
+    | GetPosts403
+    | GetPosts404
+    | GetPosts500,
 >(
   options?: {
     query?: Partial<
@@ -506,6 +583,11 @@ export type postPostsResponse401 = {
   status: 401;
 };
 
+export type postPostsResponse403 = {
+  data: PostPosts403;
+  status: 403;
+};
+
 export type postPostsResponse404 = {
   data: PostPosts404;
   status: 404;
@@ -520,6 +602,7 @@ export type postPostsResponseComposite =
   | postPostsResponse200
   | postPostsResponse400
   | postPostsResponse401
+  | postPostsResponse403
   | postPostsResponse404
   | postPostsResponse500;
 
@@ -544,7 +627,12 @@ export const postPosts = async (
 };
 
 export const getPostPostsMutationOptions = <
-  TError = ErrorResponse | PostPosts401 | PostPosts404 | PostPosts500,
+  TError =
+    | ErrorResponse
+    | PostPosts401
+    | PostPosts403
+    | PostPosts404
+    | PostPosts500,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -588,11 +676,17 @@ export type PostPostsMutationBody = PostPostsBody;
 export type PostPostsMutationError =
   | ErrorResponse
   | PostPosts401
+  | PostPosts403
   | PostPosts404
   | PostPosts500;
 
 export const usePostPosts = <
-  TError = ErrorResponse | PostPosts401 | PostPosts404 | PostPosts500,
+  TError =
+    | ErrorResponse
+    | PostPosts401
+    | PostPosts403
+    | PostPosts404
+    | PostPosts500,
   TContext = unknown,
 >(
   options?: {
@@ -631,6 +725,11 @@ export type putPostsIdResponse401 = {
   status: 401;
 };
 
+export type putPostsIdResponse403 = {
+  data: PutPostsId403;
+  status: 403;
+};
+
 export type putPostsIdResponse404 = {
   data: PutPostsId404;
   status: 404;
@@ -645,6 +744,7 @@ export type putPostsIdResponseComposite =
   | putPostsIdResponse200
   | putPostsIdResponse400
   | putPostsIdResponse401
+  | putPostsIdResponse403
   | putPostsIdResponse404
   | putPostsIdResponse500;
 
@@ -670,7 +770,12 @@ export const putPostsId = async (
 };
 
 export const getPutPostsIdMutationOptions = <
-  TError = ErrorResponse | PutPostsId401 | PutPostsId404 | PutPostsId500,
+  TError =
+    | ErrorResponse
+    | PutPostsId401
+    | PutPostsId403
+    | PutPostsId404
+    | PutPostsId500,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -714,11 +819,17 @@ export type PutPostsIdMutationBody = PutPostsIdBody;
 export type PutPostsIdMutationError =
   | ErrorResponse
   | PutPostsId401
+  | PutPostsId403
   | PutPostsId404
   | PutPostsId500;
 
 export const usePutPostsId = <
-  TError = ErrorResponse | PutPostsId401 | PutPostsId404 | PutPostsId500,
+  TError =
+    | ErrorResponse
+    | PutPostsId401
+    | PutPostsId403
+    | PutPostsId404
+    | PutPostsId500,
   TContext = unknown,
 >(
   options?: {
@@ -757,6 +868,11 @@ export type deletePostsIdResponse401 = {
   status: 401;
 };
 
+export type deletePostsIdResponse403 = {
+  data: DeletePostsId403;
+  status: 403;
+};
+
 export type deletePostsIdResponse404 = {
   data: DeletePostsId404;
   status: 404;
@@ -771,6 +887,7 @@ export type deletePostsIdResponseComposite =
   | deletePostsIdResponse200
   | deletePostsIdResponse400
   | deletePostsIdResponse401
+  | deletePostsIdResponse403
   | deletePostsIdResponse404
   | deletePostsIdResponse500;
 
@@ -796,6 +913,7 @@ export const getDeletePostsIdMutationOptions = <
   TError =
     | ErrorResponse
     | DeletePostsId401
+    | DeletePostsId403
     | DeletePostsId404
     | DeletePostsId500,
   TContext = unknown,
@@ -841,6 +959,7 @@ export type DeletePostsIdMutationResult = NonNullable<
 export type DeletePostsIdMutationError =
   | ErrorResponse
   | DeletePostsId401
+  | DeletePostsId403
   | DeletePostsId404
   | DeletePostsId500;
 
@@ -848,6 +967,7 @@ export const useDeletePostsId = <
   TError =
     | ErrorResponse
     | DeletePostsId401
+    | DeletePostsId403
     | DeletePostsId404
     | DeletePostsId500,
   TContext = unknown,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enforced post ownership: updates and deletes now return 403 Forbidden when acting on another user’s post; creation uses the authenticated user.
  - Standardized 403 Forbidden errors across the API; frontend client and hooks now surface 403 variants for relevant endpoints.

- Tests
  - Added coverage for user authentication middleware (401 vs 200) and 403 ownership scenarios across posts routes.

- Chores
  - Adjusted frontend workflow path filters to include the client directory, ensuring related changes trigger CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->