### PR TITLE
Update renovate.json: match Bun, @types/bun, oven/bun across managers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,7 @@
     },
     {
       "groupName": "bun dependencies",
-      "matchManagers": ["dockerfile", "regex", "npm", "pnpm", "yarn"],
+      "matchManagers": ["dockerfile", "regex", "npm", "bun"],
       "matchPackageNames": ["bun", "@types/bun", "oven/bun"],
       "matchPackagePatterns": ["^bun$", "^@types/bun$", "^oven/bun$"],
       "automerge": false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency update rules to consistently group Bun-related packages across multiple managers (Dockerfile, npm, regex, and Bun manager).
  * Expanded coverage to bun, @types/bun, and oven/bun with precise matching.
  * Automerge remains disabled for these updates.
  * No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->