### PR TITLE
Switch to UUID public_id for users and posts; add signup display_name

### DIFF
--- a/packages/backend_app/openapi.json
+++ b/packages/backend_app/openapi.json
@@ -580,19 +580,15 @@
         }
       }
     },
-    "/posts/{id}": {
+    "/posts/{public_id}": {
       "put": {
         "tags": ["posts"],
         "security": [{ "bearerAuth": [] }],
         "parameters": [
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "exclusiveMinimum": true
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
-            "name": "id",
+            "name": "public_id",
             "in": "path"
           }
         ],
@@ -779,13 +775,9 @@
         "security": [{ "bearerAuth": [] }],
         "parameters": [
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "exclusiveMinimum": true
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
-            "name": "id",
+            "name": "public_id",
             "in": "path"
           }
         ],

--- a/packages/backend_app/openapi.json
+++ b/packages/backend_app/openapi.json
@@ -31,24 +31,20 @@
       "user": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "integer",
-            "minimum": -2147483648,
-            "maximum": 2147483647
-          }
+          "public_id": { "type": "string", "format": "uuid" },
+          "display_name": { "type": "string" }
         },
-        "required": ["id"],
+        "required": ["public_id", "display_name"],
         "additionalProperties": false
       },
       "post": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "integer",
-            "minimum": -2147483648,
-            "maximum": 2147483647,
-            "description": "Primary ID",
-            "example": 1
+          "public_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Public ID",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
           },
           "content": {
             "type": "string",
@@ -68,7 +64,7 @@
             "example": "2025-01-01T00:00:00Z"
           }
         },
-        "required": ["id", "content", "created_at", "updated_at"],
+        "required": ["public_id", "content", "created_at", "updated_at"],
         "additionalProperties": false
       }
     },
@@ -79,6 +75,24 @@
       "post": {
         "tags": ["user"],
         "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "display_name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The display name of the user",
+                    "example": "John Doe"
+                  }
+                },
+                "required": ["display_name"]
+              }
+            }
+          }
+        },
         "responses": {
           "200": { "description": "signup" },
           "400": {

--- a/packages/backend_app/src/apps/posts/dto.ts
+++ b/packages/backend_app/src/apps/posts/dto.ts
@@ -9,10 +9,10 @@ import {
 import { userSelectSchema } from "../user/dto";
 
 const postSelectSchema = createSelectSchema(postsTable, {
-  id: (schema) =>
+  public_id: (schema) =>
     schema.openapi({
-      description: "Primary ID",
-      example: 1,
+      description: "Public ID",
+      example: "123e4567-e89b-12d3-a456-426614174000",
     }),
   content: (schema) =>
     schema.openapi({

--- a/packages/backend_app/src/apps/posts/dto.ts
+++ b/packages/backend_app/src/apps/posts/dto.ts
@@ -59,7 +59,7 @@ export const postPostResponseSchema = z.object({
 });
 
 export const updatePostParamsSchema = z.object({
-  id: z.coerce.number().int().positive(),
+  public_id: z.uuid(),
 });
 
 export const updatePostRequestSchema = createUpdateSchema(postsTable, {

--- a/packages/backend_app/src/apps/posts/index.test.ts
+++ b/packages/backend_app/src/apps/posts/index.test.ts
@@ -150,13 +150,13 @@ describe("postsApp", () => {
   });
 
   describe("updatePostRoute", () => {
-    let id: string;
+    let public_id: string;
     let content: string;
 
     const subject = () =>
-      testClient(app).posts[":id"].$put(
+      testClient(app).posts[":public_id"].$put(
         {
-          param: { id: id.toString() },
+          param: { public_id },
           json: { content },
         },
         { headers },
@@ -164,7 +164,7 @@ describe("postsApp", () => {
 
     describe("when required fields are provided", () => {
       beforeEach(() => {
-        id = Number(1).toString();
+        public_id = faker.string.uuid();
         content = "test2";
       });
 
@@ -192,7 +192,7 @@ describe("postsApp", () => {
         beforeEach(async () => {
           await db
             .insert(postsTable)
-            .values({ user_id: user.id, content: "test" });
+            .values({ public_id, user_id: user.id, content: "test" });
         });
 
         it("should return 200 Response", async () => {
@@ -219,7 +219,7 @@ describe("postsApp", () => {
         beforeEach(async () => {
           await db
             .insert(postsTable)
-            .values({ user_id: anotherUser.id, content: "test" });
+            .values({ public_id, user_id: anotherUser.id, content: "test" });
         });
 
         it("should return 403 Response", async () => {
@@ -231,7 +231,7 @@ describe("postsApp", () => {
 
     describe("when required fields are not provided", () => {
       beforeEach(() => {
-        id = Number(1).toString();
+        public_id = faker.string.uuid();
         content = "";
       });
 
@@ -243,7 +243,7 @@ describe("postsApp", () => {
 
     describe("when id is not a number", () => {
       beforeEach(() => {
-        id = "test";
+        public_id = faker.string.uuid();
       });
 
       it("should return 400 Response", async () => {
@@ -254,14 +254,17 @@ describe("postsApp", () => {
   });
 
   describe("deletePostRoute", () => {
-    let id: string;
+    let public_id: string;
 
     const subject = () =>
-      testClient(app).posts[":id"].$delete({ param: { id } }, { headers });
+      testClient(app).posts[":public_id"].$delete(
+        { param: { public_id } },
+        { headers },
+      );
 
     describe("when required fields are provided", () => {
       beforeEach(() => {
-        id = Number(1).toString();
+        public_id = faker.string.uuid();
       });
 
       describe("when Authorization header is not provided", () => {
@@ -288,7 +291,7 @@ describe("postsApp", () => {
         beforeEach(async () => {
           await db
             .insert(postsTable)
-            .values({ user_id: user.id, content: "test" });
+            .values({ public_id, user_id: user.id, content: "test" });
         });
 
         it("should return 200 Response", async () => {
@@ -304,7 +307,7 @@ describe("postsApp", () => {
         beforeEach(async () => {
           await db
             .insert(postsTable)
-            .values({ user_id: anotherUser.id, content: "test" });
+            .values({ public_id, user_id: anotherUser.id, content: "test" });
         });
 
         it("should return 403 Response", async () => {
@@ -314,9 +317,9 @@ describe("postsApp", () => {
       });
     });
 
-    describe("when id is not a number", () => {
+    describe("when public_id is not a uuid", () => {
       beforeEach(() => {
-        id = "test";
+        public_id = faker.string.alphanumeric(36);
       });
 
       it("should return 400 Response", async () => {

--- a/packages/backend_app/src/apps/posts/index.test.ts
+++ b/packages/backend_app/src/apps/posts/index.test.ts
@@ -20,7 +20,10 @@ describe("postsApp", () => {
     const _user = (
       await db
         .insert(usersTable)
-        .values({ supabase_uid: supabaseUid })
+        .values({
+          supabase_uid: supabaseUid,
+          display_name: faker.person.fullName(),
+        })
         .returning()
     )[0];
     if (!_user) throw new Error("user is not found");
@@ -29,7 +32,10 @@ describe("postsApp", () => {
     const _anotherUser = (
       await db
         .insert(usersTable)
-        .values({ supabase_uid: faker.string.uuid() })
+        .values({
+          supabase_uid: faker.string.uuid(),
+          display_name: faker.person.fullName(),
+        })
         .returning()
     )[0];
     if (!_anotherUser) throw new Error("another user is not found");
@@ -68,21 +74,23 @@ describe("postsApp", () => {
         const json = await res.json();
         expect(json.posts).toHaveLength(2);
         expect(json.posts[0]).toEqual({
-          id: 2,
+          public_id: expect.any(String),
           content: "test2",
           created_at: expect.any(String),
           updated_at: expect.any(String),
           user: {
-            id: user.id,
+            public_id: user.public_id,
+            display_name: user.display_name,
           },
         });
         expect(json.posts[1]).toEqual({
-          id: 1,
+          public_id: expect.any(String),
           content: "test",
           created_at: expect.any(String),
           updated_at: expect.any(String),
           user: {
-            id: user.id,
+            public_id: user.public_id,
+            display_name: user.display_name,
           },
         });
       });

--- a/packages/backend_app/src/apps/posts/index.ts
+++ b/packages/backend_app/src/apps/posts/index.ts
@@ -54,13 +54,16 @@ const routes = postApp
   })
 
   .openapi(updatePostRoute, async (c) => {
-    const { id } = c.req.valid("param");
+    const { public_id } = c.req.valid("param");
     const { content } = c.req.valid("json");
     const user = c.get("user");
 
     const post = await db.transaction(async (tx) => {
       const target = (
-        await tx.select().from(postsTable).where(eq(postsTable.id, id))
+        await tx
+          .select()
+          .from(postsTable)
+          .where(eq(postsTable.public_id, public_id))
       )[0];
 
       if (target === undefined) {
@@ -78,7 +81,7 @@ const routes = postApp
       const results = await tx
         .update(postsTable)
         .set({ content })
-        .where(eq(postsTable.id, id))
+        .where(eq(postsTable.public_id, public_id))
         .returning();
 
       const result = results[0];
@@ -100,12 +103,15 @@ const routes = postApp
   })
 
   .openapi(deletePostRoute, async (c) => {
-    const { id } = c.req.valid("param");
+    const { public_id } = c.req.valid("param");
     const user = c.get("user");
 
     await db.transaction(async (tx) => {
       const target = (
-        await tx.select().from(postsTable).where(eq(postsTable.id, id))
+        await tx
+          .select()
+          .from(postsTable)
+          .where(eq(postsTable.public_id, public_id))
       )[0];
 
       if (target === undefined) {
@@ -120,7 +126,7 @@ const routes = postApp
         });
       }
 
-      await tx.delete(postsTable).where(eq(postsTable.id, id));
+      await tx.delete(postsTable).where(eq(postsTable.public_id, public_id));
     });
 
     return c.json(null, 200);

--- a/packages/backend_app/src/apps/posts/route.ts
+++ b/packages/backend_app/src/apps/posts/route.ts
@@ -57,7 +57,7 @@ export const postPostRoute = createRoute({
 export const updatePostRoute = createRoute({
   tags: ["posts"],
   method: "put",
-  path: "/{id}",
+  path: "/{public_id}",
   security: [{ bearerAuth: [] }],
   request: {
     params: updatePostParamsSchema,
@@ -85,7 +85,7 @@ export const updatePostRoute = createRoute({
 export const deletePostRoute = createRoute({
   tags: ["posts"],
   method: "delete",
-  path: "/{id}",
+  path: "/{public_id}",
   security: [{ bearerAuth: [] }],
   request: {
     params: deletePostParamsSchema,

--- a/packages/backend_app/src/apps/user/dto.ts
+++ b/packages/backend_app/src/apps/user/dto.ts
@@ -1,8 +1,18 @@
 import { userPublicFields } from "../../db/field";
 import { usersTable } from "../../db/schema";
-import { createSelectSchema } from "../factory";
+import { createInsertSchema, createSelectSchema } from "../factory";
 
 export const userSelectSchema = createSelectSchema(usersTable)
   .pick(userPublicFields)
   .strict()
   .openapi("user");
+
+export const signupRequestSchema = createInsertSchema(usersTable, {
+  display_name: (schema) =>
+    schema.min(1).openapi({
+      description: "The display name of the user",
+      example: "John Doe",
+    }),
+}).pick({
+  display_name: true,
+});

--- a/packages/backend_app/src/apps/user/index.test.ts
+++ b/packages/backend_app/src/apps/user/index.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "bun:test";
+import { faker } from "@faker-js/faker";
 import type { ClientRequestOptions } from "hono/client";
 import { testClient } from "hono/testing";
 import { app } from "../../apps";
@@ -11,9 +12,12 @@ describe("userApp", () => {
     let headers: ClientRequestOptions["headers"];
 
     const subject = () =>
-      testClient(app).user.signup.$post(undefined, {
-        headers,
-      });
+      testClient(app).user.signup.$post(
+        { json: { display_name: faker.person.fullName() } },
+        {
+          headers,
+        },
+      );
 
     beforeEach(() => {
       headers = { Authorization: "Bearer test" };
@@ -44,7 +48,10 @@ describe("userApp", () => {
 
     describe("when supabase_uid is already registered", () => {
       beforeEach(async () => {
-        await db.insert(usersTable).values({ supabase_uid: supabaseUid });
+        await db.insert(usersTable).values({
+          supabase_uid: supabaseUid,
+          display_name: faker.person.fullName(),
+        });
       });
 
       it("should return 200 Response", async () => {

--- a/packages/backend_app/src/apps/user/index.ts
+++ b/packages/backend_app/src/apps/user/index.ts
@@ -10,9 +10,10 @@ userApp.use(jwtMiddleware);
 
 const routes = userApp.openapi(signupRoute, async (c) => {
   const { sub: supabase_uid } = c.get("jwtClaims");
+  const { display_name } = await c.req.valid("json");
   await db
     .insert(usersTable)
-    .values({ supabase_uid })
+    .values({ supabase_uid, display_name })
     .onConflictDoNothing({ target: usersTable.supabase_uid });
   return c.json(null, 200);
 });

--- a/packages/backend_app/src/apps/user/route.ts
+++ b/packages/backend_app/src/apps/user/route.ts
@@ -1,11 +1,21 @@
 import { createRoute } from "@hono/zod-openapi";
 import { ErrorResponses } from "../../dto/output/error";
+import { signupRequestSchema } from "./dto";
 
 export const signupRoute = createRoute({
   tags: ["user"],
   method: "post",
   path: "/signup",
   security: [{ bearerAuth: [] }],
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: signupRequestSchema,
+        },
+      },
+    },
+  },
   responses: {
     200: {
       description: "signup",

--- a/packages/backend_app/src/db/field.ts
+++ b/packages/backend_app/src/db/field.ts
@@ -1,12 +1,12 @@
 import type { postsTable, usersTable } from "./schema";
 
-// TODO: displayName などを追加したい
 export const userPublicFieldDefs = [
-  "id",
+  "public_id",
+  "display_name",
 ] satisfies (keyof typeof usersTable.$inferSelect)[];
 
 export const postPublicFieldDefs = [
-  "id",
+  "public_id",
   "content",
   "created_at",
   "updated_at",

--- a/packages/backend_app/src/db/schema.ts
+++ b/packages/backend_app/src/db/schema.ts
@@ -1,9 +1,12 @@
 import { relations } from "drizzle-orm";
 import { integer, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 
+// TODO: uuid v7 を検討
 const primaryKeys = {
   id: integer().primaryKey().generatedAlwaysAsIdentity(),
 };
+
+const publicIdColumn = () => uuid().unique().notNull().defaultRandom();
 
 const timestamps = {
   created_at: timestamp().defaultNow().notNull(),
@@ -15,12 +18,15 @@ const timestamps = {
 
 export const usersTable = pgTable("users", {
   ...primaryKeys,
+  public_id: publicIdColumn(),
   supabase_uid: uuid().unique().notNull(),
+  display_name: text().notNull(),
   ...timestamps,
 });
 
 export const postsTable = pgTable("posts", {
   ...primaryKeys,
+  public_id: publicIdColumn(),
   user_id: integer()
     .notNull()
     .references(() => usersTable.id),

--- a/packages/backend_app/src/db/schema.ts
+++ b/packages/backend_app/src/db/schema.ts
@@ -1,12 +1,10 @@
 import { relations } from "drizzle-orm";
 import { integer, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 
-// TODO: uuid v7 を検討
-const primaryKeys = {
-  id: integer().primaryKey().generatedAlwaysAsIdentity(),
-};
-
-const publicIdColumn = () => uuid().unique().notNull().defaultRandom();
+const primaryKeys = () => ({
+  id: integer().primaryKey().generatedAlwaysAsIdentity(), // TODO: uuid v7 を検討
+  public_id: uuid().unique().notNull().defaultRandom(), // uuid v4
+});
 
 const timestamps = {
   created_at: timestamp().defaultNow().notNull(),
@@ -17,16 +15,14 @@ const timestamps = {
 };
 
 export const usersTable = pgTable("users", {
-  ...primaryKeys,
-  public_id: publicIdColumn(),
+  ...primaryKeys(),
   supabase_uid: uuid().unique().notNull(),
   display_name: text().notNull(),
   ...timestamps,
 });
 
 export const postsTable = pgTable("posts", {
-  ...primaryKeys,
-  public_id: publicIdColumn(),
+  ...primaryKeys(),
   user_id: integer()
     .notNull()
     .references(() => usersTable.id),

--- a/packages/backend_app/src/middlewares/user/index.test.ts
+++ b/packages/backend_app/src/middlewares/user/index.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "bun:test";
+import { faker } from "@faker-js/faker";
 import { Hono } from "hono";
 import type { ClientRequestOptions } from "hono/client";
 import { testClient } from "hono/testing";
@@ -31,7 +32,10 @@ describe("userMiddleware", () => {
 
   describe("when user is found", () => {
     beforeEach(async () => {
-      await db.insert(usersTable).values({ supabase_uid: supabaseUid });
+      await db.insert(usersTable).values({
+        supabase_uid: supabaseUid,
+        display_name: faker.person.fullName(),
+      });
     });
 
     it("should return 200 Response", async () => {

--- a/packages/e2e/tests/scenarios/post/index.spec.ts
+++ b/packages/e2e/tests/scenarios/post/index.spec.ts
@@ -55,8 +55,8 @@ test("post page", async ({ page }, testInfo) => {
   const firstPostContent = `This is first post content`;
   const secondPostContent = `This is second post content`;
 
-  const firstPostCard = page.getByTestId("PostCard-1");
-  const secondPostCard = page.getByTestId("PostCard-2");
+  const firstPostCard = page.getByTestId("PostCard").first();
+  const secondPostCard = page.getByTestId("PostCard").nth(1);
 
   await test.step("create posts", async () => {
     const createTextArea = page.getByPlaceholder(

--- a/packages/e2e/tests/scenarios/post/index.spec.ts
+++ b/packages/e2e/tests/scenarios/post/index.spec.ts
@@ -10,6 +10,7 @@ test.beforeEach(async () => {
     method: "POST",
   });
   expect(res.status).toBe(200);
+  console.info("backend app initialized");
 });
 
 test("post page", async ({ page }, testInfo) => {

--- a/packages/e2e/tests/scenarios/post/index.spec.ts
+++ b/packages/e2e/tests/scenarios/post/index.spec.ts
@@ -39,8 +39,13 @@ test("post page", async ({ page }, testInfo) => {
     await expect(signUpDialogBtn).toBeVisible();
 
     await signUpDialogBtn.click();
-    await expect(signUpBtn).toBeVisible();
+
+    const displayNameInput = page.getByLabel("Your Name");
+    await expect(displayNameInput).toBeVisible();
     await takeSnapshot(page, testInfo);
+
+    await displayNameInput.fill("Test User");
+    await expect(signUpBtn).toBeEnabled();
 
     await signUpBtn.click();
     await expect(signUpBtn).not.toBeVisible();

--- a/packages/e2e/tests/scenarios/post/index.spec.ts
+++ b/packages/e2e/tests/scenarios/post/index.spec.ts
@@ -2,7 +2,10 @@ import { expect, takeSnapshot, test } from "@chromatic-com/playwright";
 import { env } from "../../env";
 
 test.use({
-  ignoreSelectors: [`[data-testid="PostCard-date"]`],
+  ignoreSelectors: [
+    `[data-testid="PostCard-publicId"]`,
+    `[data-testid="PostCard-date"]`,
+  ],
 });
 
 test.beforeEach(async () => {
@@ -52,71 +55,72 @@ test("post page", async ({ page }, testInfo) => {
     await expect(signUpDialogBtn).not.toBeVisible();
   });
 
-  const firstPostContent = `This is first post content`;
-  const secondPostContent = `This is second post content`;
+  const createTextArea = page.getByPlaceholder(
+    "Write your post content here...",
+  );
+  const createPostButton = page.getByRole("button", { name: "Create Post" });
 
+  const firstPostContent = `This is first post content`;
+
+  const postCards = page.getByTestId("PostCard");
   const firstPostCard = page.getByTestId("PostCard").first();
-  const secondPostCard = page.getByTestId("PostCard").nth(1);
 
   await test.step("create posts", async () => {
-    const createTextArea = page.getByPlaceholder(
-      "Write your post content here...",
-    );
-    const createPostButton = page.getByRole("button", { name: "Create Post" });
+    await createTextArea.fill(firstPostContent);
+    await createPostButton.click();
 
-    await test.step("create first post", async () => {
-      await createTextArea.fill(firstPostContent);
-      await createPostButton.click();
-      await expect(createTextArea).toHaveValue("");
-
-      await expect(firstPostCard).toBeVisible();
-      await takeSnapshot(page, testInfo);
-    });
-
-    await test.step("create second post", async () => {
-      await createTextArea.fill(secondPostContent);
-      await createPostButton.click();
-      await expect(createTextArea).toHaveValue("");
-
-      await expect(secondPostCard).toBeVisible();
-      await takeSnapshot(page, testInfo);
-    });
+    await expect(firstPostCard).toBeVisible();
+    await takeSnapshot(page, testInfo);
   });
 
   await test.step("update post", async () => {
     const editTextArea = firstPostCard.getByRole("textbox");
     const updatedPostContent = `This is updated post content`;
+    const editButton = firstPostCard.getByRole("button", { name: "Edit" });
 
-    await test.step("check first post edit button", async () => {
-      await firstPostCard.getByRole("button", { name: "Edit" }).click();
+    await test.step("check post edit button", async () => {
+      await editButton.click();
       await expect(editTextArea).toBeVisible();
       await takeSnapshot(page, testInfo);
     });
 
-    await test.step("update first post", async () => {
+    await test.step("cancel update post", async () => {
+      await firstPostCard
+        .getByRole("textbox")
+        .fill("This is not updated post content");
+      await firstPostCard.getByRole("button", { name: "Cancel" }).click();
       await expect(firstPostCard.getByText(firstPostContent)).toBeVisible();
+    });
+
+    await test.step("update post successfully", async () => {
       await expect(firstPostCard.getByText("New")).toBeVisible();
 
+      await editButton.click();
       await editTextArea.fill(updatedPostContent);
       await firstPostCard.getByRole("button", { name: "Save" }).click();
       await expect(firstPostCard.getByText(updatedPostContent)).toBeVisible();
       await expect(firstPostCard.getByText("New")).not.toBeVisible();
       await takeSnapshot(page, testInfo);
     });
-
-    await test.step("cancel update second post", async () => {
-      await secondPostCard.getByRole("button", { name: "Edit" }).click();
-      await secondPostCard
-        .getByRole("textbox")
-        .fill("This is not updated post content");
-      await secondPostCard.getByRole("button", { name: "Cancel" }).click();
-      await expect(secondPostCard.getByText(secondPostContent)).toBeVisible();
-    });
   });
 
   await test.step("delete second post", async () => {
-    await secondPostCard.getByRole("button", { name: "Delete" }).click();
-    await expect(secondPostCard).not.toBeVisible();
+    await firstPostCard.getByRole("button", { name: "Delete" }).click();
+    await expect(firstPostCard).not.toBeVisible();
+    await takeSnapshot(page, testInfo);
+  });
+
+  await test.step("create multiple posts", async () => {
+    const contents = Array.from(
+      { length: 3 },
+      (_, index) => `This is No.${index + 1} post content`,
+    );
+    for (const content of contents) {
+      await expect(createTextArea).toHaveValue("");
+      await createTextArea.fill(content);
+      await createPostButton.click();
+    }
+    await expect(postCards).toHaveCount(contents.length);
     await takeSnapshot(page, testInfo);
   });
 

--- a/packages/frontend_app/.storybook/preview.tsx
+++ b/packages/frontend_app/.storybook/preview.tsx
@@ -10,7 +10,7 @@ import { RootProviders } from "../src/lib/RootProviders";
  * See https://github.com/mswjs/msw-storybook-addon#configuring-msw
  * to learn how to customize it
  */
-initialize({}, getBackendAppOpenAPIMock());
+initialize({ onUnhandledRequest: "bypass" }, getBackendAppOpenAPIMock());
 
 const preview: Preview = {
   parameters: {

--- a/packages/frontend_app/src/client/index.msw.ts
+++ b/packages/frontend_app/src/client/index.msw.ts
@@ -18,22 +18,15 @@ export const getGetPostsResponseMock = (
     (_, i) => i + 1,
   ).map(() => ({
     ...{
-      id: faker.number.int({
-        min: -2147483648,
-        max: 2147483647,
-        multipleOf: undefined,
-      }),
+      public_id: faker.string.uuid(),
       content: faker.string.alpha({ length: { min: 10, max: 20 } }),
       created_at: `${faker.date.past().toISOString().split(".")[0]}Z`,
       updated_at: `${faker.date.past().toISOString().split(".")[0]}Z`,
     },
     ...{
       user: {
-        id: faker.number.int({
-          min: -2147483648,
-          max: 2147483647,
-          multipleOf: undefined,
-        }),
+        public_id: faker.string.uuid(),
+        display_name: faker.string.alpha({ length: { min: 10, max: 20 } }),
       },
     },
   })),
@@ -45,22 +38,15 @@ export const getPostPostsResponseMock = (
 ): PostPosts200 => ({
   post: {
     ...{
-      id: faker.number.int({
-        min: -2147483648,
-        max: 2147483647,
-        multipleOf: undefined,
-      }),
+      public_id: faker.string.uuid(),
       content: faker.string.alpha({ length: { min: 10, max: 20 } }),
       created_at: `${faker.date.past().toISOString().split(".")[0]}Z`,
       updated_at: `${faker.date.past().toISOString().split(".")[0]}Z`,
     },
     ...{
       user: {
-        id: faker.number.int({
-          min: -2147483648,
-          max: 2147483647,
-          multipleOf: undefined,
-        }),
+        public_id: faker.string.uuid(),
+        display_name: faker.string.alpha({ length: { min: 10, max: 20 } }),
       },
     },
   },
@@ -72,22 +58,15 @@ export const getPutPostsIdResponseMock = (
 ): PutPostsId200 => ({
   post: {
     ...{
-      id: faker.number.int({
-        min: -2147483648,
-        max: 2147483647,
-        multipleOf: undefined,
-      }),
+      public_id: faker.string.uuid(),
       content: faker.string.alpha({ length: { min: 10, max: 20 } }),
       created_at: `${faker.date.past().toISOString().split(".")[0]}Z`,
       updated_at: `${faker.date.past().toISOString().split(".")[0]}Z`,
     },
     ...{
       user: {
-        id: faker.number.int({
-          min: -2147483648,
-          max: 2147483647,
-          multipleOf: undefined,
-        }),
+        public_id: faker.string.uuid(),
+        display_name: faker.string.alpha({ length: { min: 10, max: 20 } }),
       },
     },
   },

--- a/packages/frontend_app/src/client/index.msw.ts
+++ b/packages/frontend_app/src/client/index.msw.ts
@@ -8,7 +8,11 @@ import { faker } from "@faker-js/faker";
 
 import { HttpResponse, http } from "msw";
 
-import type { GetPosts200, PostPosts200, PutPostsId200 } from "./index.schemas";
+import type {
+  GetPosts200,
+  PostPosts200,
+  PutPostsPublicId200,
+} from "./index.schemas";
 
 export const getGetPostsResponseMock = (
   overrideResponse: Partial<GetPosts200> = {},
@@ -53,9 +57,9 @@ export const getPostPostsResponseMock = (
   ...overrideResponse,
 });
 
-export const getPutPostsIdResponseMock = (
-  overrideResponse: Partial<PutPostsId200> = {},
-): PutPostsId200 => ({
+export const getPutPostsPublicIdResponseMock = (
+  overrideResponse: Partial<PutPostsPublicId200> = {},
+): PutPostsPublicId200 => ({
   post: {
     ...{
       public_id: faker.string.uuid(),
@@ -130,35 +134,35 @@ export const getPostPostsMockHandler = (
   });
 };
 
-export const getPutPostsIdMockHandler = (
+export const getPutPostsPublicIdMockHandler = (
   overrideResponse?:
-    | PutPostsId200
+    | PutPostsPublicId200
     | ((
         info: Parameters<Parameters<typeof http.put>[1]>[0],
-      ) => Promise<PutPostsId200> | PutPostsId200),
+      ) => Promise<PutPostsPublicId200> | PutPostsPublicId200),
 ) => {
-  return http.put("*/posts/:id", async (info) => {
+  return http.put("*/posts/:publicId", async (info) => {
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined
           ? typeof overrideResponse === "function"
             ? await overrideResponse(info)
             : overrideResponse
-          : getPutPostsIdResponseMock(),
+          : getPutPostsPublicIdResponseMock(),
       ),
       { status: 200, headers: { "Content-Type": "application/json" } },
     );
   });
 };
 
-export const getDeletePostsIdMockHandler = (
+export const getDeletePostsPublicIdMockHandler = (
   overrideResponse?:
     | null
     | ((
         info: Parameters<Parameters<typeof http.delete>[1]>[0],
       ) => Promise<null> | null),
 ) => {
-  return http.delete("*/posts/:id", async (info) => {
+  return http.delete("*/posts/:publicId", async (info) => {
     if (typeof overrideResponse === "function") {
       await overrideResponse(info);
     }
@@ -169,6 +173,6 @@ export const getBackendAppOpenAPIMock = () => [
   getPostUserSignupMockHandler(),
   getGetPostsMockHandler(),
   getPostPostsMockHandler(),
-  getPutPostsIdMockHandler(),
-  getDeletePostsIdMockHandler(),
+  getPutPostsPublicIdMockHandler(),
+  getDeletePostsPublicIdMockHandler(),
 ];

--- a/packages/frontend_app/src/client/index.schemas.ts
+++ b/packages/frontend_app/src/client/index.schemas.ts
@@ -23,20 +23,13 @@ export interface ErrorResponse {
 }
 
 export interface User {
-  /**
-   * @minimum -2147483648
-   * @maximum 2147483647
-   */
-  id: number;
+  public_id: string;
+  display_name: string;
 }
 
 export interface Post {
-  /**
-   * Primary ID
-   * @minimum -2147483648
-   * @maximum 2147483647
-   */
-  id: number;
+  /** Public ID */
+  public_id: string;
   /** The content of the post */
   content: string;
   /** The date and time the post was created */
@@ -44,6 +37,14 @@ export interface Post {
   /** The date and time the post was updated */
   updated_at: string;
 }
+
+export type PostUserSignupBody = {
+  /**
+   * The display name of the user
+   * @minLength 1
+   */
+  display_name: string;
+};
 
 export type PostUserSignup401AllOfCode =
   (typeof PostUserSignup401AllOfCode)[keyof typeof PostUserSignup401AllOfCode];

--- a/packages/frontend_app/src/client/index.schemas.ts
+++ b/packages/frontend_app/src/client/index.schemas.ts
@@ -314,7 +314,7 @@ export type PostPosts500AllOf = {
 
 export type PostPosts500 = ErrorResponse & PostPosts500AllOf;
 
-export type PutPostsIdBody = {
+export type PutPostsPublicIdBody = {
   /**
    * The content of the post
    * @minLength 1
@@ -322,21 +322,21 @@ export type PutPostsIdBody = {
   content?: string;
 };
 
-export type PutPostsId200PostAllOf = {
+export type PutPostsPublicId200PostAllOf = {
   user: User;
 };
 
-export type PutPostsId200Post = Post & PutPostsId200PostAllOf;
+export type PutPostsPublicId200Post = Post & PutPostsPublicId200PostAllOf;
 
-export type PutPostsId200 = {
-  post: PutPostsId200Post;
+export type PutPostsPublicId200 = {
+  post: PutPostsPublicId200Post;
 };
 
-export type PutPostsId401AllOfCode =
-  (typeof PutPostsId401AllOfCode)[keyof typeof PutPostsId401AllOfCode];
+export type PutPostsPublicId401AllOfCode =
+  (typeof PutPostsPublicId401AllOfCode)[keyof typeof PutPostsPublicId401AllOfCode];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PutPostsId401AllOfCode = {
+export const PutPostsPublicId401AllOfCode = {
   Bad_Request: "Bad Request",
   Unauthorized: "Unauthorized",
   Forbidden: "Forbidden",
@@ -344,19 +344,19 @@ export const PutPostsId401AllOfCode = {
   Internal_Server_Error: "Internal Server Error",
 } as const;
 
-export type PutPostsId401AllOf = {
-  code?: PutPostsId401AllOfCode;
+export type PutPostsPublicId401AllOf = {
+  code?: PutPostsPublicId401AllOfCode;
   /** explanation */
   message?: string;
 };
 
-export type PutPostsId401 = ErrorResponse & PutPostsId401AllOf;
+export type PutPostsPublicId401 = ErrorResponse & PutPostsPublicId401AllOf;
 
-export type PutPostsId403AllOfCode =
-  (typeof PutPostsId403AllOfCode)[keyof typeof PutPostsId403AllOfCode];
+export type PutPostsPublicId403AllOfCode =
+  (typeof PutPostsPublicId403AllOfCode)[keyof typeof PutPostsPublicId403AllOfCode];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PutPostsId403AllOfCode = {
+export const PutPostsPublicId403AllOfCode = {
   Bad_Request: "Bad Request",
   Unauthorized: "Unauthorized",
   Forbidden: "Forbidden",
@@ -364,19 +364,19 @@ export const PutPostsId403AllOfCode = {
   Internal_Server_Error: "Internal Server Error",
 } as const;
 
-export type PutPostsId403AllOf = {
-  code?: PutPostsId403AllOfCode;
+export type PutPostsPublicId403AllOf = {
+  code?: PutPostsPublicId403AllOfCode;
   /** explanation */
   message?: string;
 };
 
-export type PutPostsId403 = ErrorResponse & PutPostsId403AllOf;
+export type PutPostsPublicId403 = ErrorResponse & PutPostsPublicId403AllOf;
 
-export type PutPostsId404AllOfCode =
-  (typeof PutPostsId404AllOfCode)[keyof typeof PutPostsId404AllOfCode];
+export type PutPostsPublicId404AllOfCode =
+  (typeof PutPostsPublicId404AllOfCode)[keyof typeof PutPostsPublicId404AllOfCode];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PutPostsId404AllOfCode = {
+export const PutPostsPublicId404AllOfCode = {
   Bad_Request: "Bad Request",
   Unauthorized: "Unauthorized",
   Forbidden: "Forbidden",
@@ -384,19 +384,19 @@ export const PutPostsId404AllOfCode = {
   Internal_Server_Error: "Internal Server Error",
 } as const;
 
-export type PutPostsId404AllOf = {
-  code?: PutPostsId404AllOfCode;
+export type PutPostsPublicId404AllOf = {
+  code?: PutPostsPublicId404AllOfCode;
   /** explanation */
   message?: string;
 };
 
-export type PutPostsId404 = ErrorResponse & PutPostsId404AllOf;
+export type PutPostsPublicId404 = ErrorResponse & PutPostsPublicId404AllOf;
 
-export type PutPostsId500AllOfCode =
-  (typeof PutPostsId500AllOfCode)[keyof typeof PutPostsId500AllOfCode];
+export type PutPostsPublicId500AllOfCode =
+  (typeof PutPostsPublicId500AllOfCode)[keyof typeof PutPostsPublicId500AllOfCode];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PutPostsId500AllOfCode = {
+export const PutPostsPublicId500AllOfCode = {
   Bad_Request: "Bad Request",
   Unauthorized: "Unauthorized",
   Forbidden: "Forbidden",
@@ -404,19 +404,19 @@ export const PutPostsId500AllOfCode = {
   Internal_Server_Error: "Internal Server Error",
 } as const;
 
-export type PutPostsId500AllOf = {
-  code?: PutPostsId500AllOfCode;
+export type PutPostsPublicId500AllOf = {
+  code?: PutPostsPublicId500AllOfCode;
   /** explanation */
   message?: string;
 };
 
-export type PutPostsId500 = ErrorResponse & PutPostsId500AllOf;
+export type PutPostsPublicId500 = ErrorResponse & PutPostsPublicId500AllOf;
 
-export type DeletePostsId401AllOfCode =
-  (typeof DeletePostsId401AllOfCode)[keyof typeof DeletePostsId401AllOfCode];
+export type DeletePostsPublicId401AllOfCode =
+  (typeof DeletePostsPublicId401AllOfCode)[keyof typeof DeletePostsPublicId401AllOfCode];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DeletePostsId401AllOfCode = {
+export const DeletePostsPublicId401AllOfCode = {
   Bad_Request: "Bad Request",
   Unauthorized: "Unauthorized",
   Forbidden: "Forbidden",
@@ -424,19 +424,20 @@ export const DeletePostsId401AllOfCode = {
   Internal_Server_Error: "Internal Server Error",
 } as const;
 
-export type DeletePostsId401AllOf = {
-  code?: DeletePostsId401AllOfCode;
+export type DeletePostsPublicId401AllOf = {
+  code?: DeletePostsPublicId401AllOfCode;
   /** explanation */
   message?: string;
 };
 
-export type DeletePostsId401 = ErrorResponse & DeletePostsId401AllOf;
+export type DeletePostsPublicId401 = ErrorResponse &
+  DeletePostsPublicId401AllOf;
 
-export type DeletePostsId403AllOfCode =
-  (typeof DeletePostsId403AllOfCode)[keyof typeof DeletePostsId403AllOfCode];
+export type DeletePostsPublicId403AllOfCode =
+  (typeof DeletePostsPublicId403AllOfCode)[keyof typeof DeletePostsPublicId403AllOfCode];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DeletePostsId403AllOfCode = {
+export const DeletePostsPublicId403AllOfCode = {
   Bad_Request: "Bad Request",
   Unauthorized: "Unauthorized",
   Forbidden: "Forbidden",
@@ -444,19 +445,20 @@ export const DeletePostsId403AllOfCode = {
   Internal_Server_Error: "Internal Server Error",
 } as const;
 
-export type DeletePostsId403AllOf = {
-  code?: DeletePostsId403AllOfCode;
+export type DeletePostsPublicId403AllOf = {
+  code?: DeletePostsPublicId403AllOfCode;
   /** explanation */
   message?: string;
 };
 
-export type DeletePostsId403 = ErrorResponse & DeletePostsId403AllOf;
+export type DeletePostsPublicId403 = ErrorResponse &
+  DeletePostsPublicId403AllOf;
 
-export type DeletePostsId404AllOfCode =
-  (typeof DeletePostsId404AllOfCode)[keyof typeof DeletePostsId404AllOfCode];
+export type DeletePostsPublicId404AllOfCode =
+  (typeof DeletePostsPublicId404AllOfCode)[keyof typeof DeletePostsPublicId404AllOfCode];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DeletePostsId404AllOfCode = {
+export const DeletePostsPublicId404AllOfCode = {
   Bad_Request: "Bad Request",
   Unauthorized: "Unauthorized",
   Forbidden: "Forbidden",
@@ -464,19 +466,20 @@ export const DeletePostsId404AllOfCode = {
   Internal_Server_Error: "Internal Server Error",
 } as const;
 
-export type DeletePostsId404AllOf = {
-  code?: DeletePostsId404AllOfCode;
+export type DeletePostsPublicId404AllOf = {
+  code?: DeletePostsPublicId404AllOfCode;
   /** explanation */
   message?: string;
 };
 
-export type DeletePostsId404 = ErrorResponse & DeletePostsId404AllOf;
+export type DeletePostsPublicId404 = ErrorResponse &
+  DeletePostsPublicId404AllOf;
 
-export type DeletePostsId500AllOfCode =
-  (typeof DeletePostsId500AllOfCode)[keyof typeof DeletePostsId500AllOfCode];
+export type DeletePostsPublicId500AllOfCode =
+  (typeof DeletePostsPublicId500AllOfCode)[keyof typeof DeletePostsPublicId500AllOfCode];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DeletePostsId500AllOfCode = {
+export const DeletePostsPublicId500AllOfCode = {
   Bad_Request: "Bad Request",
   Unauthorized: "Unauthorized",
   Forbidden: "Forbidden",
@@ -484,10 +487,11 @@ export const DeletePostsId500AllOfCode = {
   Internal_Server_Error: "Internal Server Error",
 } as const;
 
-export type DeletePostsId500AllOf = {
-  code?: DeletePostsId500AllOfCode;
+export type DeletePostsPublicId500AllOf = {
+  code?: DeletePostsPublicId500AllOfCode;
   /** explanation */
   message?: string;
 };
 
-export type DeletePostsId500 = ErrorResponse & DeletePostsId500AllOf;
+export type DeletePostsPublicId500 = ErrorResponse &
+  DeletePostsPublicId500AllOf;

--- a/packages/frontend_app/src/client/index.ts
+++ b/packages/frontend_app/src/client/index.ts
@@ -44,6 +44,7 @@ import type {
   PostUserSignup403,
   PostUserSignup404,
   PostUserSignup500,
+  PostUserSignupBody,
   PutPostsId200,
   PutPostsId401,
   PutPostsId403,
@@ -105,11 +106,14 @@ export const getPostUserSignupUrl = () => {
 };
 
 export const postUserSignup = async (
+  postUserSignupBody: PostUserSignupBody,
   options?: RequestInit,
 ): Promise<postUserSignupResponse> => {
   return customFetch<postUserSignupResponse>(getPostUserSignupUrl(), {
     ...options,
     method: "POST",
+    headers: { "Content-Type": "application/json", ...options?.headers },
+    body: JSON.stringify(postUserSignupBody),
   });
 };
 
@@ -125,14 +129,14 @@ export const getPostUserSignupMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof postUserSignup>>,
     TError,
-    void,
+    { data: PostUserSignupBody },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof postUserSignup>>,
   TError,
-  void,
+  { data: PostUserSignupBody },
   TContext
 > => {
   const mutationKey = ["postUserSignup"];
@@ -146,9 +150,11 @@ export const getPostUserSignupMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof postUserSignup>>,
-    void
-  > = () => {
-    return postUserSignup(requestOptions);
+    { data: PostUserSignupBody }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return postUserSignup(data, requestOptions);
   };
 
   return { mutationFn, ...mutationOptions };
@@ -157,7 +163,7 @@ export const getPostUserSignupMutationOptions = <
 export type PostUserSignupMutationResult = NonNullable<
   Awaited<ReturnType<typeof postUserSignup>>
 >;
-
+export type PostUserSignupMutationBody = PostUserSignupBody;
 export type PostUserSignupMutationError =
   | ErrorResponse
   | PostUserSignup401
@@ -178,7 +184,7 @@ export const usePostUserSignup = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof postUserSignup>>,
       TError,
-      void,
+      { data: PostUserSignupBody },
       TContext
     >;
     request?: SecondParameter<typeof customFetch>;
@@ -187,7 +193,7 @@ export const usePostUserSignup = <
 ): UseMutationResult<
   Awaited<ReturnType<typeof postUserSignup>>,
   TError,
-  void,
+  { data: PostUserSignupBody },
   TContext
 > => {
   const mutationOptions = getPostUserSignupMutationOptions(options);

--- a/packages/frontend_app/src/client/index.ts
+++ b/packages/frontend_app/src/client/index.ts
@@ -24,10 +24,10 @@ import type {
 import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { customFetch } from "../lib/custom-fetch";
 import type {
-  DeletePostsId401,
-  DeletePostsId403,
-  DeletePostsId404,
-  DeletePostsId500,
+  DeletePostsPublicId401,
+  DeletePostsPublicId403,
+  DeletePostsPublicId404,
+  DeletePostsPublicId500,
   ErrorResponse,
   GetPosts200,
   GetPosts401,
@@ -45,12 +45,12 @@ import type {
   PostUserSignup404,
   PostUserSignup500,
   PostUserSignupBody,
-  PutPostsId200,
-  PutPostsId401,
-  PutPostsId403,
-  PutPostsId404,
-  PutPostsId500,
-  PutPostsIdBody,
+  PutPostsPublicId200,
+  PutPostsPublicId401,
+  PutPostsPublicId403,
+  PutPostsPublicId404,
+  PutPostsPublicId500,
+  PutPostsPublicIdBody,
 } from "./index.schemas";
 
 type AwaitedInput<T> = PromiseLike<T> | T;
@@ -716,88 +716,91 @@ export const usePostPosts = <
   return useMutation(mutationOptions, queryClient);
 };
 
-export type putPostsIdResponse200 = {
-  data: PutPostsId200;
+export type putPostsPublicIdResponse200 = {
+  data: PutPostsPublicId200;
   status: 200;
 };
 
-export type putPostsIdResponse400 = {
+export type putPostsPublicIdResponse400 = {
   data: ErrorResponse;
   status: 400;
 };
 
-export type putPostsIdResponse401 = {
-  data: PutPostsId401;
+export type putPostsPublicIdResponse401 = {
+  data: PutPostsPublicId401;
   status: 401;
 };
 
-export type putPostsIdResponse403 = {
-  data: PutPostsId403;
+export type putPostsPublicIdResponse403 = {
+  data: PutPostsPublicId403;
   status: 403;
 };
 
-export type putPostsIdResponse404 = {
-  data: PutPostsId404;
+export type putPostsPublicIdResponse404 = {
+  data: PutPostsPublicId404;
   status: 404;
 };
 
-export type putPostsIdResponse500 = {
-  data: PutPostsId500;
+export type putPostsPublicIdResponse500 = {
+  data: PutPostsPublicId500;
   status: 500;
 };
 
-export type putPostsIdResponseComposite =
-  | putPostsIdResponse200
-  | putPostsIdResponse400
-  | putPostsIdResponse401
-  | putPostsIdResponse403
-  | putPostsIdResponse404
-  | putPostsIdResponse500;
+export type putPostsPublicIdResponseComposite =
+  | putPostsPublicIdResponse200
+  | putPostsPublicIdResponse400
+  | putPostsPublicIdResponse401
+  | putPostsPublicIdResponse403
+  | putPostsPublicIdResponse404
+  | putPostsPublicIdResponse500;
 
-export type putPostsIdResponse = putPostsIdResponseComposite & {
+export type putPostsPublicIdResponse = putPostsPublicIdResponseComposite & {
   headers: Headers;
 };
 
-export const getPutPostsIdUrl = (id: number) => {
-  return `/posts/${id}`;
+export const getPutPostsPublicIdUrl = (publicId: string) => {
+  return `/posts/${publicId}`;
 };
 
-export const putPostsId = async (
-  id: number,
-  putPostsIdBody: PutPostsIdBody,
+export const putPostsPublicId = async (
+  publicId: string,
+  putPostsPublicIdBody: PutPostsPublicIdBody,
   options?: RequestInit,
-): Promise<putPostsIdResponse> => {
-  return customFetch<putPostsIdResponse>(getPutPostsIdUrl(id), {
-    ...options,
-    method: "PUT",
-    headers: { "Content-Type": "application/json", ...options?.headers },
-    body: JSON.stringify(putPostsIdBody),
-  });
+): Promise<putPostsPublicIdResponse> => {
+  return customFetch<putPostsPublicIdResponse>(
+    getPutPostsPublicIdUrl(publicId),
+    {
+      ...options,
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...options?.headers },
+      body: JSON.stringify(putPostsPublicIdBody),
+    },
+  );
 };
 
-export const getPutPostsIdMutationOptions = <
+export const getPutPostsPublicIdMutationOptions = <
   TError =
     | ErrorResponse
-    | PutPostsId401
-    | PutPostsId403
-    | PutPostsId404
-    | PutPostsId500,
+    | PutPostsPublicId401
+    | PutPostsPublicId403
+    | PutPostsPublicId404
+    | PutPostsPublicId500,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof putPostsId>>,
+    Awaited<ReturnType<typeof putPostsPublicId>>,
     TError,
-    { id: number; data: PutPostsIdBody },
+    { publicId: string; data: PutPostsPublicIdBody },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): UseMutationOptions<
-  Awaited<ReturnType<typeof putPostsId>>,
+  Awaited<ReturnType<typeof putPostsPublicId>>,
   TError,
-  { id: number; data: PutPostsIdBody },
+  { publicId: string; data: PutPostsPublicIdBody },
   TContext
 > => {
-  const mutationKey = ["putPostsId"];
+  const mutationKey = ["putPostsPublicId"];
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       "mutationKey" in options.mutation &&
@@ -807,137 +810,141 @@ export const getPutPostsIdMutationOptions = <
     : { mutation: { mutationKey }, request: undefined };
 
   const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof putPostsId>>,
-    { id: number; data: PutPostsIdBody }
+    Awaited<ReturnType<typeof putPostsPublicId>>,
+    { publicId: string; data: PutPostsPublicIdBody }
   > = (props) => {
-    const { id, data } = props ?? {};
+    const { publicId, data } = props ?? {};
 
-    return putPostsId(id, data, requestOptions);
+    return putPostsPublicId(publicId, data, requestOptions);
   };
 
   return { mutationFn, ...mutationOptions };
 };
 
-export type PutPostsIdMutationResult = NonNullable<
-  Awaited<ReturnType<typeof putPostsId>>
+export type PutPostsPublicIdMutationResult = NonNullable<
+  Awaited<ReturnType<typeof putPostsPublicId>>
 >;
-export type PutPostsIdMutationBody = PutPostsIdBody;
-export type PutPostsIdMutationError =
+export type PutPostsPublicIdMutationBody = PutPostsPublicIdBody;
+export type PutPostsPublicIdMutationError =
   | ErrorResponse
-  | PutPostsId401
-  | PutPostsId403
-  | PutPostsId404
-  | PutPostsId500;
+  | PutPostsPublicId401
+  | PutPostsPublicId403
+  | PutPostsPublicId404
+  | PutPostsPublicId500;
 
-export const usePutPostsId = <
+export const usePutPostsPublicId = <
   TError =
     | ErrorResponse
-    | PutPostsId401
-    | PutPostsId403
-    | PutPostsId404
-    | PutPostsId500,
+    | PutPostsPublicId401
+    | PutPostsPublicId403
+    | PutPostsPublicId404
+    | PutPostsPublicId500,
   TContext = unknown,
 >(
   options?: {
     mutation?: UseMutationOptions<
-      Awaited<ReturnType<typeof putPostsId>>,
+      Awaited<ReturnType<typeof putPostsPublicId>>,
       TError,
-      { id: number; data: PutPostsIdBody },
+      { publicId: string; data: PutPostsPublicIdBody },
       TContext
     >;
     request?: SecondParameter<typeof customFetch>;
   },
   queryClient?: QueryClient,
 ): UseMutationResult<
-  Awaited<ReturnType<typeof putPostsId>>,
+  Awaited<ReturnType<typeof putPostsPublicId>>,
   TError,
-  { id: number; data: PutPostsIdBody },
+  { publicId: string; data: PutPostsPublicIdBody },
   TContext
 > => {
-  const mutationOptions = getPutPostsIdMutationOptions(options);
+  const mutationOptions = getPutPostsPublicIdMutationOptions(options);
 
   return useMutation(mutationOptions, queryClient);
 };
 
-export type deletePostsIdResponse200 = {
+export type deletePostsPublicIdResponse200 = {
   data: null;
   status: 200;
 };
 
-export type deletePostsIdResponse400 = {
+export type deletePostsPublicIdResponse400 = {
   data: ErrorResponse;
   status: 400;
 };
 
-export type deletePostsIdResponse401 = {
-  data: DeletePostsId401;
+export type deletePostsPublicIdResponse401 = {
+  data: DeletePostsPublicId401;
   status: 401;
 };
 
-export type deletePostsIdResponse403 = {
-  data: DeletePostsId403;
+export type deletePostsPublicIdResponse403 = {
+  data: DeletePostsPublicId403;
   status: 403;
 };
 
-export type deletePostsIdResponse404 = {
-  data: DeletePostsId404;
+export type deletePostsPublicIdResponse404 = {
+  data: DeletePostsPublicId404;
   status: 404;
 };
 
-export type deletePostsIdResponse500 = {
-  data: DeletePostsId500;
+export type deletePostsPublicIdResponse500 = {
+  data: DeletePostsPublicId500;
   status: 500;
 };
 
-export type deletePostsIdResponseComposite =
-  | deletePostsIdResponse200
-  | deletePostsIdResponse400
-  | deletePostsIdResponse401
-  | deletePostsIdResponse403
-  | deletePostsIdResponse404
-  | deletePostsIdResponse500;
+export type deletePostsPublicIdResponseComposite =
+  | deletePostsPublicIdResponse200
+  | deletePostsPublicIdResponse400
+  | deletePostsPublicIdResponse401
+  | deletePostsPublicIdResponse403
+  | deletePostsPublicIdResponse404
+  | deletePostsPublicIdResponse500;
 
-export type deletePostsIdResponse = deletePostsIdResponseComposite & {
-  headers: Headers;
+export type deletePostsPublicIdResponse =
+  deletePostsPublicIdResponseComposite & {
+    headers: Headers;
+  };
+
+export const getDeletePostsPublicIdUrl = (publicId: string) => {
+  return `/posts/${publicId}`;
 };
 
-export const getDeletePostsIdUrl = (id: number) => {
-  return `/posts/${id}`;
-};
-
-export const deletePostsId = async (
-  id: number,
+export const deletePostsPublicId = async (
+  publicId: string,
   options?: RequestInit,
-): Promise<deletePostsIdResponse> => {
-  return customFetch<deletePostsIdResponse>(getDeletePostsIdUrl(id), {
-    ...options,
-    method: "DELETE",
-  });
+): Promise<deletePostsPublicIdResponse> => {
+  return customFetch<deletePostsPublicIdResponse>(
+    getDeletePostsPublicIdUrl(publicId),
+    {
+      ...options,
+      method: "DELETE",
+    },
+  );
 };
 
-export const getDeletePostsIdMutationOptions = <
+export const getDeletePostsPublicIdMutationOptions = <
   TError =
     | ErrorResponse
-    | DeletePostsId401
-    | DeletePostsId403
-    | DeletePostsId404
-    | DeletePostsId500,
+    | DeletePostsPublicId401
+    | DeletePostsPublicId403
+    | DeletePostsPublicId404
+    | DeletePostsPublicId500,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof deletePostsId>>,
+    Awaited<ReturnType<typeof deletePostsPublicId>>,
     TError,
-    { id: number },
+    { publicId: string },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): UseMutationOptions<
-  Awaited<ReturnType<typeof deletePostsId>>,
+  Awaited<ReturnType<typeof deletePostsPublicId>>,
   TError,
-  { id: number },
+  { publicId: string },
   TContext
 > => {
-  const mutationKey = ["deletePostsId"];
+  const mutationKey = ["deletePostsPublicId"];
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       "mutationKey" in options.mutation &&
@@ -947,54 +954,54 @@ export const getDeletePostsIdMutationOptions = <
     : { mutation: { mutationKey }, request: undefined };
 
   const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof deletePostsId>>,
-    { id: number }
+    Awaited<ReturnType<typeof deletePostsPublicId>>,
+    { publicId: string }
   > = (props) => {
-    const { id } = props ?? {};
+    const { publicId } = props ?? {};
 
-    return deletePostsId(id, requestOptions);
+    return deletePostsPublicId(publicId, requestOptions);
   };
 
   return { mutationFn, ...mutationOptions };
 };
 
-export type DeletePostsIdMutationResult = NonNullable<
-  Awaited<ReturnType<typeof deletePostsId>>
+export type DeletePostsPublicIdMutationResult = NonNullable<
+  Awaited<ReturnType<typeof deletePostsPublicId>>
 >;
 
-export type DeletePostsIdMutationError =
+export type DeletePostsPublicIdMutationError =
   | ErrorResponse
-  | DeletePostsId401
-  | DeletePostsId403
-  | DeletePostsId404
-  | DeletePostsId500;
+  | DeletePostsPublicId401
+  | DeletePostsPublicId403
+  | DeletePostsPublicId404
+  | DeletePostsPublicId500;
 
-export const useDeletePostsId = <
+export const useDeletePostsPublicId = <
   TError =
     | ErrorResponse
-    | DeletePostsId401
-    | DeletePostsId403
-    | DeletePostsId404
-    | DeletePostsId500,
+    | DeletePostsPublicId401
+    | DeletePostsPublicId403
+    | DeletePostsPublicId404
+    | DeletePostsPublicId500,
   TContext = unknown,
 >(
   options?: {
     mutation?: UseMutationOptions<
-      Awaited<ReturnType<typeof deletePostsId>>,
+      Awaited<ReturnType<typeof deletePostsPublicId>>,
       TError,
-      { id: number },
+      { publicId: string },
       TContext
     >;
     request?: SecondParameter<typeof customFetch>;
   },
   queryClient?: QueryClient,
 ): UseMutationResult<
-  Awaited<ReturnType<typeof deletePostsId>>,
+  Awaited<ReturnType<typeof deletePostsPublicId>>,
   TError,
-  { id: number },
+  { publicId: string },
   TContext
 > => {
-  const mutationOptions = getDeletePostsIdMutationOptions(options);
+  const mutationOptions = getDeletePostsPublicIdMutationOptions(options);
 
   return useMutation(mutationOptions, queryClient);
 };

--- a/packages/frontend_app/src/components/features/SignUpDialog/index.stories.tsx
+++ b/packages/frontend_app/src/components/features/SignUpDialog/index.stories.tsx
@@ -35,9 +35,15 @@ export const SignUpSuccess: Story = {
     });
     await userEvent.click(signUpDialogBtn);
 
+    const displayNameInput = await screen.findByLabelText("Your Name");
+    await waitFor(async () => {
+      await expect(displayNameInput).toBeVisible();
+    });
+    await userEvent.type(displayNameInput, "Test User");
+
     const signUpBtn = await screen.findByRole("button", { name: "Sign Up" });
     await waitFor(async () => {
-      await expect(signUpBtn).toBeVisible();
+      await expect(signUpBtn).toBeEnabled();
     });
 
     await userEvent.click(signUpBtn);

--- a/packages/frontend_app/src/components/features/SignUpDialog/index.tsx
+++ b/packages/frontend_app/src/components/features/SignUpDialog/index.tsx
@@ -33,11 +33,6 @@ export const SignUpDialog = () => {
     startLoadingTransition(async () => {
       e.preventDefault();
 
-      if (!displayName.trim()) {
-        toast.error("Display name is required");
-        return;
-      }
-
       const result = await supabase.auth.signInAnonymously();
       if (result.error) {
         toast.error(result.error.message);

--- a/packages/frontend_app/src/components/pages/post/components/PostCard/index.stories.ts
+++ b/packages/frontend_app/src/components/pages/post/components/PostCard/index.stories.ts
@@ -1,4 +1,3 @@
-import { faker } from "@faker-js/faker";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import type { ComponentProps } from "react";
 import { expect, userEvent, waitFor, within } from "storybook/test";
@@ -13,7 +12,8 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 type Props = ComponentProps<typeof PostCard>;
-const postId: Props["post"]["public_id"] = faker.string.uuid();
+const postId: Props["post"]["public_id"] =
+  "b07530d9-82c0-4662-aed0-fcc4539ebd29";
 const postContent: Props["post"]["content"] = "Test post content";
 const createMockPost = (
   overrides: Partial<Props["post"]> = {},

--- a/packages/frontend_app/src/components/pages/post/components/PostCard/index.stories.ts
+++ b/packages/frontend_app/src/components/pages/post/components/PostCard/index.stories.ts
@@ -12,12 +12,13 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 type Props = ComponentProps<typeof PostCard>;
-const postId: Props["post"]["id"] = 1;
+const postId: Props["post"]["public_id"] =
+  "123e4567-e89b-12d3-a456-426614174000";
 const postContent: Props["post"]["content"] = "Test post content";
 const createMockPost = (
   overrides: Partial<Props["post"]> = {},
 ): Props["post"] => ({
-  id: postId,
+  public_id: postId,
   content: postContent,
   created_at: "2025-01-01T00:00:00.000Z",
   updated_at: "2025-01-01T00:00:00.000Z",

--- a/packages/frontend_app/src/components/pages/post/components/PostCard/index.stories.ts
+++ b/packages/frontend_app/src/components/pages/post/components/PostCard/index.stories.ts
@@ -1,3 +1,4 @@
+import { faker } from "@faker-js/faker";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import type { ComponentProps } from "react";
 import { expect, userEvent, waitFor, within } from "storybook/test";
@@ -12,8 +13,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 type Props = ComponentProps<typeof PostCard>;
-const postId: Props["post"]["public_id"] =
-  "123e4567-e89b-12d3-a456-426614174000";
+const postId: Props["post"]["public_id"] = faker.string.uuid();
 const postContent: Props["post"]["content"] = "Test post content";
 const createMockPost = (
   overrides: Partial<Props["post"]> = {},
@@ -26,7 +26,7 @@ const createMockPost = (
 });
 
 const getPostCardElements = (canvas: ReturnType<typeof within>) => {
-  const postCard = canvas.getByTestId(`PostCard-${postId}`);
+  const postCard = canvas.getByTestId(`PostCard`);
   const header = within(postCard).getByTestId("PostCard-header");
   const content = within(postCard).getByTestId("PostCard-content");
   const date = within(postCard).getByTestId("PostCard-date");

--- a/packages/frontend_app/src/components/pages/post/components/PostCard/index.tsx
+++ b/packages/frontend_app/src/components/pages/post/components/PostCard/index.tsx
@@ -73,7 +73,7 @@ export const PostCard = ({ post }: PostCardProps) => {
 
   return (
     <div
-      data-testid={`PostCard-${post.public_id}`}
+      data-testid="PostCard"
       className="bg-white rounded-lg shadow-sm border border-gray-200 hover:shadow-md transition-shadow duration-200 overflow-hidden"
     >
       <div className="p-6">

--- a/packages/frontend_app/src/components/pages/post/components/PostCard/index.tsx
+++ b/packages/frontend_app/src/components/pages/post/components/PostCard/index.tsx
@@ -79,9 +79,9 @@ export const PostCard = ({ post }: PostCardProps) => {
       <div className="p-6">
         <div
           data-testid="PostCard-header"
-          className="flex items-start justify-between gap-2 mb-4 min-w-0"
+          className="flex flex-wrap items-start justify-between gap-2 mb-4 min-w-0"
         >
-          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 w-0 flex-1 min-w-0 max-w-full md:max-w-xs lg:max-w-sm">
+          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 w-0 flex-1 min-w-0 max-w-[65%] sm:max-w-[60%] md:flex-none md:w-auto md:max-w-fit">
             <span data-testid="PostCard-publicId" className="truncate">
               {post.public_id}
             </span>

--- a/packages/frontend_app/src/components/pages/post/components/PostCard/index.tsx
+++ b/packages/frontend_app/src/components/pages/post/components/PostCard/index.tsx
@@ -79,9 +79,9 @@ export const PostCard = ({ post }: PostCardProps) => {
       <div className="p-6">
         <div
           data-testid="PostCard-header"
-          className="flex items-start justify-between gap-2 mb-4"
+          className="flex items-start justify-between gap-2 mb-4 min-w-0"
         >
-          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 max-w-fit">
+          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 w-0 flex-1 min-w-0 max-w-full md:flex-none md:w-auto md:max-w-fit">
             <span data-testid="PostCard-publicId" className="truncate">
               {post.public_id}
             </span>

--- a/packages/frontend_app/src/components/pages/post/components/PostCard/index.tsx
+++ b/packages/frontend_app/src/components/pages/post/components/PostCard/index.tsx
@@ -81,7 +81,7 @@ export const PostCard = ({ post }: PostCardProps) => {
           data-testid="PostCard-header"
           className="flex items-start justify-between gap-2 mb-4 min-w-0"
         >
-          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 w-0 flex-1 min-w-0 max-w-full md:flex-none md:w-auto md:max-w-fit">
+          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 w-0 flex-1 min-w-0 max-w-full md:max-w-xs lg:max-w-sm">
             <span data-testid="PostCard-publicId" className="truncate">
               {post.public_id}
             </span>

--- a/packages/frontend_app/src/components/pages/post/components/PostCard/index.tsx
+++ b/packages/frontend_app/src/components/pages/post/components/PostCard/index.tsx
@@ -81,7 +81,7 @@ export const PostCard = ({ post }: PostCardProps) => {
           data-testid="PostCard-header"
           className="flex items-start justify-between gap-2 mb-4"
         >
-          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 min-w-0 flex-1">
+          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 max-w-fit">
             <span data-testid="PostCard-publicId" className="truncate">
               {post.public_id}
             </span>

--- a/packages/frontend_app/src/components/pages/post/components/PostCard/index.tsx
+++ b/packages/frontend_app/src/components/pages/post/components/PostCard/index.tsx
@@ -5,14 +5,14 @@ import { useState } from "react";
 import { toast } from "sonner";
 import {
   getGetPostsQueryKey,
-  useDeletePostsId,
-  usePutPostsId,
+  useDeletePostsPublicId,
+  usePutPostsPublicId,
 } from "../../../../../client";
 import { formatDate } from "../../../../../lib/dateUtils";
 import { Button } from "../../../../ui/Button";
 
 type Post = {
-  id: number;
+  public_id: string;
   content: string;
   created_at: string;
   updated_at: string;
@@ -29,8 +29,8 @@ export const PostCard = ({ post }: PostCardProps) => {
   const [editContent, setEditContent] = useState(post.content);
   const isUpdated = post.updated_at !== post.created_at;
 
-  const updatePostMutation = usePutPostsId();
-  const deletePostMutation = useDeletePostsId();
+  const updatePostMutation = usePutPostsPublicId();
+  const deletePostMutation = useDeletePostsPublicId();
 
   const handleEdit = () => {
     setIsEditing(true);
@@ -46,7 +46,7 @@ export const PostCard = ({ post }: PostCardProps) => {
     const trimmedContent = editContent.trim();
     if (!trimmedContent) return;
     const result = await updatePostMutation.mutateAsync({
-      id: post.id,
+      publicId: post.public_id,
       data: { content: trimmedContent },
     });
 
@@ -60,7 +60,9 @@ export const PostCard = ({ post }: PostCardProps) => {
   };
 
   const handleDelete = async () => {
-    const result = await deletePostMutation.mutateAsync({ id: post.id });
+    const result = await deletePostMutation.mutateAsync({
+      publicId: post.public_id,
+    });
     if (result.status !== 200) {
       toast.error(`Failed to delete post: ${result.data.message}`);
       return;
@@ -71,7 +73,7 @@ export const PostCard = ({ post }: PostCardProps) => {
 
   return (
     <div
-      data-testid={`PostCard-${post.id}`}
+      data-testid={`PostCard-${post.public_id}`}
       className="bg-white rounded-lg shadow-sm border border-gray-200 hover:shadow-md transition-shadow duration-200 overflow-hidden"
     >
       <div className="p-6">
@@ -80,7 +82,7 @@ export const PostCard = ({ post }: PostCardProps) => {
           className="flex items-start justify-between mb-4"
         >
           <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-            ID: {post.id}
+            ID: {post.public_id}
           </span>
           <div className="flex items-center gap-2">
             <div className="text-xs text-gray-400">

--- a/packages/frontend_app/src/components/pages/post/components/PostCard/index.tsx
+++ b/packages/frontend_app/src/components/pages/post/components/PostCard/index.tsx
@@ -79,12 +79,12 @@ export const PostCard = ({ post }: PostCardProps) => {
       <div className="p-6">
         <div
           data-testid="PostCard-header"
-          className="flex items-start justify-between mb-4"
+          className="flex items-start justify-between gap-2 mb-4"
         >
-          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-            ID: {post.public_id}
+          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 min-w-0 flex-1">
+            <span className="truncate">{post.public_id}</span>
           </span>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 flex-shrink-0">
             <div className="text-xs text-gray-400">
               {isUpdated ? "Updated" : "New"}
             </div>

--- a/packages/frontend_app/src/components/pages/post/components/PostCard/index.tsx
+++ b/packages/frontend_app/src/components/pages/post/components/PostCard/index.tsx
@@ -82,7 +82,9 @@ export const PostCard = ({ post }: PostCardProps) => {
           className="flex items-start justify-between gap-2 mb-4"
         >
           <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 min-w-0 flex-1">
-            <span className="truncate">{post.public_id}</span>
+            <span data-testid="PostCard-publicId" className="truncate">
+              {post.public_id}
+            </span>
           </span>
           <div className="flex items-center gap-2 flex-shrink-0">
             <div className="text-xs text-gray-400">

--- a/packages/frontend_app/src/components/pages/post/index.tsx
+++ b/packages/frontend_app/src/components/pages/post/index.tsx
@@ -57,9 +57,11 @@ export const PostIndex = () => {
         {posts.length === 0 ? (
           <EmptyState />
         ) : (
-          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          <div className="grid grid-cols-[repeat(auto-fit,minmax(320px,1fr))] gap-6">
             {posts.map((post) => (
-              <PostCard key={post.public_id} post={post} />
+              <div key={post.public_id} className="min-w-0">
+                <PostCard post={post} />
+              </div>
             ))}
           </div>
         )}

--- a/packages/frontend_app/src/components/pages/post/index.tsx
+++ b/packages/frontend_app/src/components/pages/post/index.tsx
@@ -25,7 +25,7 @@ export const PostIndex = () => {
 
   return (
     <div className="min-h-screen bg-gray-50 p-4 sm:p-8">
-      <div className="max-w-4xl mx-auto">
+      <div className="max-w-6xl mx-auto">
         <div className="mb-8">
           <div className="mb-6 flex justify-between items-start">
             <div>

--- a/packages/frontend_app/src/components/pages/post/index.tsx
+++ b/packages/frontend_app/src/components/pages/post/index.tsx
@@ -57,9 +57,12 @@ export const PostIndex = () => {
         {posts.length === 0 ? (
           <EmptyState />
         ) : (
-          <div className="grid grid-cols-[repeat(auto-fit,minmax(320px,1fr))] gap-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 justify-items-center">
             {posts.map((post) => (
-              <div key={post.public_id} className="min-w-0">
+              <div
+                key={post.public_id}
+                className="min-w-0 w-full max-w-[90%] sm:max-w-full"
+              >
                 <PostCard post={post} />
               </div>
             ))}

--- a/packages/frontend_app/src/components/pages/post/index.tsx
+++ b/packages/frontend_app/src/components/pages/post/index.tsx
@@ -59,7 +59,7 @@ export const PostIndex = () => {
         ) : (
           <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
             {posts.map((post) => (
-              <PostCard key={post.id} post={post} />
+              <PostCard key={post.public_id} post={post} />
             ))}
           </div>
         )}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Sign-up now requires a validated display name and includes it in the signup payload.

- **Refactor**
  - Replaced internal numeric IDs with public UUIDs (public_id) across API surfaces and client types.

- **UI**
  - Post cards display truncated public IDs; page layout widened and minor header/layout adjustments; sign-up dialog now includes a required name input.

- **Tests & Mocks**
  - E2E/unit tests and MSW mocks updated for public_id/display_name; Storybook MSW set to bypass unhandled requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->