### PR TITLE
feat(backend): extend post_logs with delete audit and event metadata

### DIFF
--- a/packages/backend_app/src/application/posts.test.ts
+++ b/packages/backend_app/src/application/posts.test.ts
@@ -77,9 +77,14 @@ describe("application/posts", () => {
       it("returns posts ordered by id descending with user relation", async () => {
         const posts = await subject();
         expect(posts).toHaveLength(2);
-        expect(posts[0]?.content).toBe("newer");
-        expect(posts[1]?.content).toBe("older");
-        expect(posts[0]?.user.public_id).toBe(user.public_id);
+        expect(posts[0]).toMatchObject({
+          content: "newer",
+          user: { public_id: user.public_id },
+        });
+        expect(posts[1]).toMatchObject({
+          content: "older",
+          user: { public_id: user.public_id },
+        });
       });
     });
   });
@@ -119,9 +124,10 @@ describe("application/posts", () => {
 
       it("returns post with user", async () => {
         const row = await subject();
-        expect(row).toBeDefined();
-        expect(row?.content).toBe("hello");
-        expect(row?.user.public_id).toBe(user.public_id);
+        expect(row).toMatchObject({
+          content: "hello",
+          user: { public_id: user.public_id },
+        });
       });
     });
   });
@@ -155,9 +161,10 @@ describe("application/posts", () => {
 
       it("returns post with user", async () => {
         const row = await subject();
-        expect(row).toBeDefined();
-        expect(row?.content).toBe("by-public");
-        expect(row?.user.display_name).toBe(user.display_name);
+        expect(row).toMatchObject({
+          content: "by-public",
+          user: { display_name: user.display_name },
+        });
       });
     });
   });
@@ -179,13 +186,24 @@ describe("application/posts", () => {
         expect(typeof result.id).toBe("number");
 
         const row = await findPostWithUserById(result.id);
-        expect(row?.content).toBe(content);
-        expect(row?.user.public_id).toBe(user.public_id);
+        if (!row) throw new Error("expected post");
+        expect(row).toMatchObject({
+          content,
+          user: { public_id: user.public_id },
+        });
 
         const logs = await db.select().from(postLogsTable);
         expect(logs).toHaveLength(1);
-        expect(logs[0]?.content).toBe(content);
-        expect(logs[0]?.user_id).toBe(user.id);
+        const log = logs[0];
+        if (!log) throw new Error("expected log");
+        expect(log).toMatchObject({
+          content,
+          user_id: user.id,
+          event_type: "created",
+          first_created_at: row.first_created_at,
+          created_at: row.created_at,
+          occurred_at: row.created_at,
+        });
       });
     });
   });
@@ -233,7 +251,8 @@ describe("application/posts", () => {
           .select()
           .from(postsTable)
           .where(eq(postsTable.public_id, publicId));
-        expect(rows[0]?.content).toBe("theirs");
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({ content: "theirs" });
       });
     });
 
@@ -267,17 +286,29 @@ describe("application/posts", () => {
         expect(rows).toHaveLength(1);
         const post = rows[0];
         if (!post) throw new Error("post is not found");
-        expect(post.public_id).toBe(publicId);
-        expect(post.content).toBe(updateContent);
-        expect(post.first_created_at).toEqual(firstAt);
+        expect(post).toMatchObject({
+          public_id: publicId,
+          content: updateContent,
+          first_created_at: firstAt,
+        });
 
         const logs = await db.select().from(postLogsTable);
         expect(logs).toHaveLength(1);
-        expect(logs[0]?.content).toBe(updateContent);
-        expect(logs[0]?.id).toBe(post.id);
+        const log = logs[0];
+        if (!log) throw new Error("expected log");
+        expect(log).toMatchObject({
+          content: updateContent,
+          id: post.id,
+          event_type: "updated",
+          first_created_at: firstAt,
+          created_at: post.created_at,
+        });
+        expect(log.occurred_at.getTime()).toBeGreaterThanOrEqual(
+          log.created_at.getTime(),
+        );
 
         const withUser = await findPostWithUserByPublicId(publicId);
-        expect(withUser?.content).toBe(updateContent);
+        expect(withUser).toMatchObject({ content: updateContent });
       });
     });
   });
@@ -320,9 +351,12 @@ describe("application/posts", () => {
     });
 
     describe("when post belongs to current user", () => {
+      let seededCreatedAt: Date;
+
       beforeEach(async () => {
         publicId = faker.string.uuid();
         const now = new Date();
+        seededCreatedAt = now;
         await db.insert(postsTable).values({
           public_id: publicId,
           user_id: user.id,
@@ -332,11 +366,30 @@ describe("application/posts", () => {
         });
       });
 
-      it("returns ok and removes the post", async () => {
+      it("returns ok and removes the post and appends deleted post_log", async () => {
+        const beforeMs = Date.now();
         expect(await subject()).toEqual({ ok: true });
+        const afterMs = Date.now();
 
         const rows = await db.select().from(postsTable);
         expect(rows).toHaveLength(0);
+
+        const logs = await db
+          .select()
+          .from(postLogsTable)
+          .where(eq(postLogsTable.public_id, publicId));
+        expect(logs).toHaveLength(1);
+        const log = logs[0];
+        if (!log) throw new Error("expected log");
+        expect(log).toMatchObject({
+          event_type: "deleted",
+          content: "gone",
+          user_id: user.id,
+          first_created_at: seededCreatedAt,
+          created_at: seededCreatedAt,
+        });
+        expect(log.occurred_at.getTime()).toBeGreaterThanOrEqual(beforeMs);
+        expect(log.occurred_at.getTime()).toBeLessThanOrEqual(afterMs);
       });
     });
   });

--- a/packages/backend_app/src/application/posts.test.ts
+++ b/packages/backend_app/src/application/posts.test.ts
@@ -202,8 +202,10 @@ describe("application/posts", () => {
           event_type: "created",
           first_created_at: row.first_created_at,
           created_at: row.created_at,
-          occurred_at: row.created_at,
         });
+        expect(log.occurred_at.getTime()).toBeGreaterThanOrEqual(
+          row.created_at.getTime(),
+        );
       });
     });
   });

--- a/packages/backend_app/src/application/posts.test.ts
+++ b/packages/backend_app/src/application/posts.test.ts
@@ -13,7 +13,6 @@ import {
   updatePostByPublicId,
 } from "./posts";
 
-/** 本番と同じ経路で posts + post_logs(created) を用意する */
 async function seedPostAsUser(input: { userId: number; content: string }) {
   const result = await createPost({
     userId: input.userId,
@@ -177,11 +176,15 @@ describe("application/posts", () => {
           user: { public_id: user.public_id },
         });
 
-        const logs = await db.select().from(postLogsTable);
+        const logs = await db
+          .select()
+          .from(postLogsTable)
+          .where(eq(postLogsTable.public_id, row.public_id));
         expect(logs).toHaveLength(1);
         const log = logs[0];
         if (!log) throw new Error("expected log");
         expect(log).toMatchObject({
+          id: result.id,
           content,
           user_id: user.id,
           event_type: "created",
@@ -325,6 +328,7 @@ describe("application/posts", () => {
 
     describe("when post belongs to current user", () => {
       let seededCreatedAt: Date;
+      let seededPostId: number;
 
       beforeEach(async () => {
         const inserted = await seedPostAsUser({
@@ -333,6 +337,7 @@ describe("application/posts", () => {
         });
         publicId = inserted.public_id;
         seededCreatedAt = inserted.first_created_at;
+        seededPostId = inserted.id;
       });
 
       it("returns ok and removes the post and appends deleted post_log", async () => {
@@ -347,10 +352,11 @@ describe("application/posts", () => {
           .select()
           .from(postLogsTable)
           .where(eq(postLogsTable.public_id, publicId));
-        expect(logs).toHaveLength(1);
-        const log = logs[0];
-        if (!log) throw new Error("expected log");
+        expect(logs).toHaveLength(2);
+        const log = logs.find((l) => l.event_type === "deleted");
+        if (!log) throw new Error("expected deleted log");
         expect(log).toMatchObject({
+          id: seededPostId,
           event_type: "deleted",
           content: "gone",
           user_id: user.id,

--- a/packages/backend_app/src/application/posts.test.ts
+++ b/packages/backend_app/src/application/posts.test.ts
@@ -13,6 +13,18 @@ import {
   updatePostByPublicId,
 } from "./posts";
 
+/** 本番と同じ経路で posts + post_logs(created) を用意する */
+async function seedPostAsUser(input: { userId: number; content: string }) {
+  const result = await createPost({
+    userId: input.userId,
+    content: input.content,
+  });
+  if (!result.ok) throw new Error("seed createPost failed");
+  const row = await findPostWithUserById(result.id);
+  if (!row) throw new Error("seed post not found");
+  return { id: result.id, ...row };
+}
+
 describe("application/posts", () => {
   let user: typeof usersTable.$inferSelect;
   let anotherUser: typeof usersTable.$inferSelect;
@@ -57,21 +69,8 @@ describe("application/posts", () => {
 
     describe("when there are some posts", () => {
       beforeEach(async () => {
-        const now = new Date();
-        await db.insert(postsTable).values({
-          public_id: faker.string.uuid(),
-          user_id: user.id,
-          content: "older",
-          first_created_at: now,
-          created_at: now,
-        });
-        await db.insert(postsTable).values({
-          public_id: faker.string.uuid(),
-          user_id: user.id,
-          content: "newer",
-          first_created_at: now,
-          created_at: now,
-        });
+        await seedPostAsUser({ userId: user.id, content: "older" });
+        await seedPostAsUser({ userId: user.id, content: "newer" });
       });
 
       it("returns posts ordered by id descending with user relation", async () => {
@@ -105,20 +104,10 @@ describe("application/posts", () => {
 
     describe("when post exists", () => {
       beforeEach(async () => {
-        const now = new Date();
-        const inserted = (
-          await db
-            .insert(postsTable)
-            .values({
-              public_id: faker.string.uuid(),
-              user_id: user.id,
-              content: "hello",
-              first_created_at: now,
-              created_at: now,
-            })
-            .returning()
-        )[0];
-        if (!inserted) throw new Error("post is not found");
+        const inserted = await seedPostAsUser({
+          userId: user.id,
+          content: "hello",
+        });
         lookupId = inserted.id;
       });
 
@@ -148,15 +137,11 @@ describe("application/posts", () => {
 
     describe("when post exists", () => {
       beforeEach(async () => {
-        lookupPublicId = faker.string.uuid();
-        const now = new Date();
-        await db.insert(postsTable).values({
-          public_id: lookupPublicId,
-          user_id: user.id,
+        const inserted = await seedPostAsUser({
+          userId: user.id,
           content: "by-public",
-          first_created_at: now,
-          created_at: now,
         });
+        lookupPublicId = inserted.public_id;
       });
 
       it("returns post with user", async () => {
@@ -233,16 +218,12 @@ describe("application/posts", () => {
 
     describe("when post belongs to another user", () => {
       beforeEach(async () => {
-        publicId = faker.string.uuid();
         updateContent = "hijack";
-        const now = new Date();
-        await db.insert(postsTable).values({
-          public_id: publicId,
-          user_id: anotherUser.id,
+        const inserted = await seedPostAsUser({
+          userId: anotherUser.id,
           content: "theirs",
-          first_created_at: now,
-          created_at: now,
         });
+        publicId = inserted.public_id;
       });
 
       it("returns forbidden and does not change content", async () => {
@@ -262,22 +243,13 @@ describe("application/posts", () => {
       let firstAt: Date;
 
       beforeEach(async () => {
-        publicId = faker.string.uuid();
-        firstAt = new Date("2020-01-01T00:00:00.000Z");
         updateContent = "after";
-        const inserted = (
-          await db
-            .insert(postsTable)
-            .values({
-              public_id: publicId,
-              user_id: user.id,
-              content: "before",
-              first_created_at: firstAt,
-              created_at: firstAt,
-            })
-            .returning()
-        )[0];
-        if (!inserted) throw new Error("post is not found");
+        const inserted = await seedPostAsUser({
+          userId: user.id,
+          content: "before",
+        });
+        publicId = inserted.public_id;
+        firstAt = inserted.first_created_at;
       });
 
       it("returns ok and replaces content while keeping first_created_at and public_id", async () => {
@@ -294,10 +266,13 @@ describe("application/posts", () => {
           first_created_at: firstAt,
         });
 
-        const logs = await db.select().from(postLogsTable);
-        expect(logs).toHaveLength(1);
-        const log = logs[0];
-        if (!log) throw new Error("expected log");
+        const logs = await db
+          .select()
+          .from(postLogsTable)
+          .where(eq(postLogsTable.public_id, publicId));
+        expect(logs).toHaveLength(2);
+        const log = logs.find((l) => l.event_type === "updated");
+        if (!log) throw new Error("expected updated log");
         expect(log).toMatchObject({
           content: updateContent,
           id: post.id,
@@ -332,15 +307,11 @@ describe("application/posts", () => {
 
     describe("when post belongs to another user", () => {
       beforeEach(async () => {
-        publicId = faker.string.uuid();
-        const now = new Date();
-        await db.insert(postsTable).values({
-          public_id: publicId,
-          user_id: anotherUser.id,
+        const inserted = await seedPostAsUser({
+          userId: anotherUser.id,
           content: "keep",
-          first_created_at: now,
-          created_at: now,
         });
+        publicId = inserted.public_id;
       });
 
       it("returns forbidden and keeps the post", async () => {
@@ -356,16 +327,12 @@ describe("application/posts", () => {
       let seededCreatedAt: Date;
 
       beforeEach(async () => {
-        publicId = faker.string.uuid();
-        const now = new Date();
-        seededCreatedAt = now;
-        await db.insert(postsTable).values({
-          public_id: publicId,
-          user_id: user.id,
+        const inserted = await seedPostAsUser({
+          userId: user.id,
           content: "gone",
-          first_created_at: now,
-          created_at: now,
         });
+        publicId = inserted.public_id;
+        seededCreatedAt = inserted.first_created_at;
       });
 
       it("returns ok and removes the post and appends deleted post_log", async () => {

--- a/packages/backend_app/src/application/posts.ts
+++ b/packages/backend_app/src/application/posts.ts
@@ -46,7 +46,6 @@ export async function createPost(input: {
 }): Promise<
   { ok: true; id: number } | { ok: false; error: PostApplicationError }
 > {
-  const now = new Date();
   const inserted = await db.transaction(async (tx) => {
     const post = (
       await tx
@@ -55,8 +54,6 @@ export async function createPost(input: {
           public_id: crypto.randomUUID(),
           user_id: input.userId,
           content: input.content,
-          first_created_at: now,
-          created_at: now,
         })
         .returning()
     )[0];
@@ -69,7 +66,6 @@ export async function createPost(input: {
       content: post.content,
       first_created_at: post.first_created_at,
       event_type: "created",
-      occurred_at: now,
       created_at: post.created_at,
     });
 
@@ -123,7 +119,6 @@ export async function updatePostByPublicId(input: {
         return tx.rollback();
       }
 
-      const occurredAt = new Date();
       await tx.insert(postLogsTable).values({
         id: row.id,
         public_id: row.public_id,
@@ -131,7 +126,6 @@ export async function updatePostByPublicId(input: {
         content: row.content,
         first_created_at: row.first_created_at,
         event_type: "updated",
-        occurred_at: occurredAt,
         created_at: row.created_at,
       });
 
@@ -170,7 +164,6 @@ export async function deletePostByPublicId(input: {
       return { kind: "abort" as const, error: "forbidden" as const };
     }
 
-    const occurredAt = new Date();
     await tx.insert(postLogsTable).values({
       id: target.id,
       public_id: target.public_id,
@@ -178,7 +171,6 @@ export async function deletePostByPublicId(input: {
       content: target.content,
       first_created_at: target.first_created_at,
       event_type: "deleted",
-      occurred_at: occurredAt,
       created_at: target.created_at,
     });
 

--- a/packages/backend_app/src/application/posts.ts
+++ b/packages/backend_app/src/application/posts.ts
@@ -67,6 +67,9 @@ export async function createPost(input: {
       public_id: post.public_id,
       user_id: post.user_id,
       content: post.content,
+      first_created_at: post.first_created_at,
+      event_type: "created",
+      occurred_at: now,
       created_at: post.created_at,
     });
 
@@ -120,11 +123,15 @@ export async function updatePostByPublicId(input: {
         return tx.rollback();
       }
 
+      const occurredAt = new Date();
       await tx.insert(postLogsTable).values({
         id: row.id,
         public_id: row.public_id,
         user_id: row.user_id,
         content: row.content,
+        first_created_at: row.first_created_at,
+        event_type: "updated",
+        occurred_at: occurredAt,
         created_at: row.created_at,
       });
 
@@ -162,6 +169,18 @@ export async function deletePostByPublicId(input: {
     if (input.actorUserId !== target.user_id) {
       return { kind: "abort" as const, error: "forbidden" as const };
     }
+
+    const occurredAt = new Date();
+    await tx.insert(postLogsTable).values({
+      id: target.id,
+      public_id: target.public_id,
+      user_id: target.user_id,
+      content: target.content,
+      first_created_at: target.first_created_at,
+      event_type: "deleted",
+      occurred_at: occurredAt,
+      created_at: target.created_at,
+    });
 
     await tx.delete(postsTable).where(eq(postsTable.public_id, input.publicId));
 

--- a/packages/backend_app/src/apps/posts/index.test.ts
+++ b/packages/backend_app/src/apps/posts/index.test.ts
@@ -129,9 +129,11 @@ describe("postsApp", () => {
 
         if (!res.ok) throw new Error("res is not ok");
         const json = await res.json();
-        expect(json.post.content).toBe(content);
-        expect(json.post.updated_at).toBeNull();
-        expect(json.post.public_id).toEqual(expect.any(String));
+        expect(json.post).toMatchObject({
+          content,
+          updated_at: null,
+          public_id: expect.any(String),
+        });
       });
     });
 
@@ -183,7 +185,7 @@ describe("postsApp", () => {
 
         if (res.ok) throw new Error("res is ok");
         const json = await res.json();
-        expect(json.message).toBe("Post is not found");
+        expect(json).toMatchObject({ message: "Post is not found" });
       });
 
       describe("when post is found", () => {
@@ -207,9 +209,11 @@ describe("postsApp", () => {
 
           if (!res.ok) throw new Error("res is not ok");
           const json = await res.json();
-          expect(json.post.content).toBe(content);
-          expect(json.post.public_id).toBe(public_id);
-          expect(json.post.updated_at).toEqual(expect.any(String));
+          expect(json.post).toMatchObject({
+            content,
+            public_id,
+            updated_at: expect.any(String),
+          });
         });
       });
 
@@ -285,7 +289,7 @@ describe("postsApp", () => {
 
         if (res.ok) throw new Error("res is ok");
         const json = await res.json();
-        expect(json.message).toBe("Post is not found");
+        expect(json).toMatchObject({ message: "Post is not found" });
       });
 
       describe("when post is found", () => {

--- a/packages/backend_app/src/apps/user/index.test.ts
+++ b/packages/backend_app/src/apps/user/index.test.ts
@@ -30,9 +30,9 @@ describe("userApp", () => {
       const users = await db.select().from(usersTable);
       expect(users).toHaveLength(1);
 
-      const user = users[0];
-      if (!user) throw new Error("user is not found");
-      expect(user.supabase_uid).toBe(supabaseUid);
+      const u = users[0];
+      if (!u) throw new Error("user is not found");
+      expect(u).toMatchObject({ supabase_uid: supabaseUid });
     });
 
     describe("when Authorization header is not provided", () => {
@@ -62,9 +62,9 @@ describe("userApp", () => {
         const users = await db.select().from(usersTable);
         expect(users).toHaveLength(1);
 
-        const user = users[0];
-        if (!user) throw new Error("user is not found");
-        expect(user.supabase_uid).toBe(supabaseUid);
+        const u = users[0];
+        if (!u) throw new Error("user is not found");
+        expect(u).toMatchObject({ supabase_uid: supabaseUid });
       });
     });
   });

--- a/packages/backend_app/src/db/schema.ts
+++ b/packages/backend_app/src/db/schema.ts
@@ -36,7 +36,7 @@ export const postsTable = pgTable("posts", {
     .notNull()
     .references(() => usersTable.id),
   content: text().notNull(),
-  first_created_at: timestamp().notNull(), // 最初の作成日時を保持（delete&insert方式のため）
+  first_created_at: timestamp().defaultNow().notNull(), // 作成時は DB デフォルト。更新時は直前行から引き継ぐ
   ...timestamps,
 });
 
@@ -54,6 +54,6 @@ export const postLogsTable = pgTable("post_logs", {
   content: text().notNull(),
   first_created_at: timestamp().notNull(),
   event_type: postLogEventEnum("event_type").notNull(),
-  occurred_at: timestamp().notNull(),
+  occurred_at: timestamp().defaultNow().notNull(),
   created_at: timestamp().notNull(),
 });

--- a/packages/backend_app/src/db/schema.ts
+++ b/packages/backend_app/src/db/schema.ts
@@ -16,7 +16,7 @@ export const postLogEventEnum = pgEnum("post_log_event", [
 
 const primaryKeys = () => ({
   id: integer().primaryKey().generatedAlwaysAsIdentity(), // TODO: uuid v7 を検討
-  public_id: uuid().unique().notNull(), // uuid v4
+  public_id: uuid().unique().notNull(),
 });
 
 const timestamps = {
@@ -36,7 +36,7 @@ export const postsTable = pgTable("posts", {
     .notNull()
     .references(() => usersTable.id),
   content: text().notNull(),
-  first_created_at: timestamp().defaultNow().notNull(), // 作成時は DB デフォルト。更新時は直前行から引き継ぐ
+  first_created_at: timestamp().defaultNow().notNull(),
   ...timestamps,
 });
 
@@ -48,7 +48,8 @@ export const postsRelations = relations(postsTable, ({ one }) => ({
 }));
 
 export const postLogsTable = pgTable("post_logs", {
-  id: integer().primaryKey(),
+  log_id: integer().primaryKey().generatedAlwaysAsIdentity(),
+  id: integer().notNull(),
   public_id: uuid().notNull(),
   user_id: integer().notNull(),
   content: text().notNull(),

--- a/packages/backend_app/src/db/schema.ts
+++ b/packages/backend_app/src/db/schema.ts
@@ -1,5 +1,18 @@
 import { relations } from "drizzle-orm";
-import { integer, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import {
+  integer,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+} from "drizzle-orm/pg-core";
+
+export const postLogEventEnum = pgEnum("post_log_event", [
+  "created",
+  "updated",
+  "deleted",
+]);
 
 const primaryKeys = () => ({
   id: integer().primaryKey().generatedAlwaysAsIdentity(), // TODO: uuid v7 を検討
@@ -39,5 +52,8 @@ export const postLogsTable = pgTable("post_logs", {
   public_id: uuid().notNull(),
   user_id: integer().notNull(),
   content: text().notNull(),
-  ...timestamps,
+  first_created_at: timestamp().notNull(),
+  event_type: postLogEventEnum("event_type").notNull(),
+  occurred_at: timestamp().notNull(),
+  created_at: timestamp().notNull(),
 });

--- a/packages/backend_app/src/db/schema.ts
+++ b/packages/backend_app/src/db/schema.ts
@@ -14,30 +14,40 @@ export const postLogEventEnum = pgEnum("post_log_event", [
   "deleted",
 ]);
 
-const primaryKeys = () => ({
-  id: integer().primaryKey().generatedAlwaysAsIdentity(), // TODO: uuid v7 を検討
-  public_id: uuid().unique().notNull(),
-});
+const primaryKeyFactories = {
+  entity: () => ({
+    id: integer().primaryKey().generatedAlwaysAsIdentity(), // TODO: uuid v7 を検討
+    public_id: uuid().unique().notNull(),
+  }),
+  log: () => ({
+    id: integer().notNull(),
+    public_id: uuid().notNull(),
+  }),
+} as const;
 
 const timestamps = {
   created_at: timestamp().defaultNow().notNull(),
 };
 
-export const usersTable = pgTable("users", {
-  ...primaryKeys(),
-  supabase_uid: uuid().unique().notNull(),
-  display_name: text().notNull(),
-  ...timestamps,
-});
-
-export const postsTable = pgTable("posts", {
-  ...primaryKeys(),
+const postTableColumns = {
   user_id: integer()
     .notNull()
     .references(() => usersTable.id),
   content: text().notNull(),
   first_created_at: timestamp().defaultNow().notNull(),
   ...timestamps,
+};
+
+export const usersTable = pgTable("users", {
+  ...primaryKeyFactories.entity(),
+  supabase_uid: uuid().unique().notNull(),
+  display_name: text().notNull(),
+  ...timestamps,
+});
+
+export const postsTable = pgTable("posts", {
+  ...primaryKeyFactories.entity(),
+  ...postTableColumns,
 });
 
 export const postsRelations = relations(postsTable, ({ one }) => ({
@@ -49,12 +59,8 @@ export const postsRelations = relations(postsTable, ({ one }) => ({
 
 export const postLogsTable = pgTable("post_logs", {
   log_id: integer().primaryKey().generatedAlwaysAsIdentity(),
-  id: integer().notNull(),
-  public_id: uuid().notNull(),
-  user_id: integer().notNull(),
-  content: text().notNull(),
-  first_created_at: timestamp().notNull(),
+  ...primaryKeyFactories.log(),
+  ...postTableColumns,
   event_type: postLogEventEnum("event_type").notNull(),
   occurred_at: timestamp().defaultNow().notNull(),
-  created_at: timestamp().notNull(),
 });


### PR DESCRIPTION
## 概要

`post_logs` を拡張し、作成・更新に加え **削除直前のスナップショット** を追記する。監査で「版の時刻」と「イベント時刻」を分けるため **`occurred_at`** を追加し、**`event_type`**（created / updated / deleted）で意味を区別する。

## 方針

- `created_at` は常にスナップショット元の `posts.created_at` の写し、`first_created_at` は論理投稿の初回作成時刻を継承。
- 現仕様では操作者は投稿所有者に限るため、**`actor_user_id` は冗長のため持たず `user_id` に統一**。
- テストは `toMatchObject` 等で整理。

## マージ前

開発・本番 DB には `drizzle-kit push`（またはマイグレーション）でスキーマ反映が必要。

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test helper and replaced direct seeding; strengthened assertions to use object matching and to verify post lifecycle logs, event types, and timing/ordering invariants for create/update/delete flows.

* **Refactor**
  * Post event logging now records explicit event types (created/updated/deleted) and additional timestamps; posts rely on database defaults for initial creation timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->